### PR TITLE
refactor: extract shared groove actions into useGrooveActions hook

### DIFF
--- a/src/components/GrooveEditor.tsx
+++ b/src/components/GrooveEditor.tsx
@@ -1,11 +1,12 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { GrooveData, DEFAULT_GROOVE, DrumVoice, TimeSignature, Division, ALL_DRUM_VOICES, createEmptyNotesRecord, MAX_MEASURES } from '../types';
+import { useState, useEffect, useMemo, useRef } from 'react';
+import { GrooveData, DEFAULT_GROOVE, DrumVoice, TimeSignature, Division, ALL_DRUM_VOICES } from '../types';
 import { SyncMode, GrooveUtils } from '../core';
 import { useGrooveEngine } from '../hooks/useGrooveEngine';
 import { useHistory } from '../hooks/useHistory';
 import { useURLSync } from '../hooks/useURLSync';
 import { useAutoSpeedUp } from '../hooks/useAutoSpeedUp';
-import DrumGrid, { NoteChange } from './DrumGrid';
+import { useGrooveActions } from '../hooks/useGrooveActions';
+import DrumGrid from './DrumGrid';
 import PlaybackControls from './PlaybackControls';
 import TempoControl from './TempoControl';
 import PresetSelector from './PresetSelector';
@@ -53,6 +54,19 @@ function App() {
 
   // URL sync: load groove from URL on init, update URL on changes
   const { copyURLToClipboard } = useURLSync(groove, setGroove);
+
+  // Shared groove actions (note toggling, measure manipulation, metadata)
+  const {
+    handleNoteToggle,
+    handleSetNotes,
+    handleMeasureDuplicate,
+    handleMeasureAdd,
+    handleMeasureRemove,
+    handleMeasureClear,
+    handleTitleChange,
+    handleAuthorChange,
+    handleCommentsChange,
+  } = useGrooveActions(groove, setGroove);
 
   // Centralized engine sync: automatically update engine when groove changes
   // This eliminates the need for manual updateGroove calls throughout the codebase
@@ -152,103 +166,6 @@ function App() {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [canUndo, canRedo, undo, redo]);
 
-  const handleNoteToggle = (voice: DrumVoice, position: number, measureIndex: number) => {
-    const newMeasures = groove.measures.map((measure, idx) => {
-      if (idx !== measureIndex) return measure;
-      return {
-        ...measure,
-        notes: {
-          ...measure.notes,
-          [voice]: measure.notes[voice].map((note, i) => (i === position ? !note : note)),
-        },
-      };
-    });
-    const newGroove = { ...groove, measures: newMeasures };
-    setGroove(newGroove);
-    // Engine sync handled by centralized useEffect
-  };
-
-  // Batch set multiple notes at once (avoids React state batching issues)
-  const handleSetNotes = useCallback((changes: NoteChange[]) => {
-    const newMeasures = groove.measures.map((measure, measureIdx) => {
-      // Get all changes for this measure
-      const measureChanges = changes.filter(c => c.measureIndex === measureIdx);
-      if (measureChanges.length === 0) return measure;
-
-      // Apply all changes to this measure's notes
-      const newNotes = { ...measure.notes };
-      for (const change of measureChanges) {
-        newNotes[change.voice] = newNotes[change.voice].map((note, i) =>
-          i === change.position ? change.value : note
-        );
-      }
-      return { ...measure, notes: newNotes };
-    });
-    const newGroove = { ...groove, measures: newMeasures };
-    setGroove(newGroove);
-    // Engine sync handled by centralized useEffect
-  }, [groove, setGroove]);
-
-  // Measure manipulation handlers
-  const handleMeasureDuplicate = useCallback((measureIndex: number) => {
-    if (groove.measures.length >= MAX_MEASURES) return;
-    const measureToCopy = groove.measures[measureIndex];
-    // Deep copy the notes
-    const copiedNotes = Object.fromEntries(
-      Object.entries(measureToCopy.notes).map(([voice, notes]) => [voice, [...notes]])
-    ) as typeof measureToCopy.notes;
-    const newMeasure = { ...measureToCopy, notes: copiedNotes };
-    const newMeasures = [
-      ...groove.measures.slice(0, measureIndex + 1),
-      newMeasure,
-      ...groove.measures.slice(measureIndex + 1),
-    ];
-    const newGroove = { ...groove, measures: newMeasures };
-    setGroove(newGroove);
-    // Engine sync handled by centralized useEffect
-  }, [groove, setGroove]);
-
-  const handleMeasureAdd = useCallback((afterIndex: number) => {
-    if (groove.measures.length >= MAX_MEASURES) return;
-    const notesPerMeasure = GrooveUtils.calcNotesPerMeasure(
-      groove.division,
-      groove.timeSignature.beats,
-      groove.timeSignature.noteValue
-    );
-    const newMeasure = { notes: createEmptyNotesRecord(notesPerMeasure) };
-    const newMeasures = [
-      ...groove.measures.slice(0, afterIndex + 1),
-      newMeasure,
-      ...groove.measures.slice(afterIndex + 1),
-    ];
-    const newGroove = { ...groove, measures: newMeasures };
-    setGroove(newGroove);
-    // Engine sync handled by centralized useEffect
-  }, [groove, setGroove]);
-
-  const handleMeasureRemove = useCallback((measureIndex: number) => {
-    if (groove.measures.length <= 1) return;
-    const newMeasures = groove.measures.filter((_, idx) => idx !== measureIndex);
-    const newGroove = { ...groove, measures: newMeasures };
-    setGroove(newGroove);
-    // Engine sync handled by centralized useEffect
-  }, [groove, setGroove]);
-
-  const handleMeasureClear = useCallback((measureIndex: number) => {
-    const notesPerMeasure = GrooveUtils.calcNotesPerMeasure(
-      groove.division,
-      groove.timeSignature.beats,
-      groove.timeSignature.noteValue
-    );
-    const newMeasures = groove.measures.map((measure, idx) => {
-      if (idx !== measureIndex) return measure;
-      return { ...measure, notes: createEmptyNotesRecord(notesPerMeasure) };
-    });
-    const newGroove = { ...groove, measures: newMeasures };
-    setGroove(newGroove);
-    // Engine sync handled by centralized useEffect
-  }, [groove, setGroove]);
-
   const handlePlay = async () => {
     // Stop auto speed up when using regular play
     if (autoSpeedUp.isActive) {
@@ -280,22 +197,6 @@ function App() {
     setGroove(newGroove);
     // Engine sync handled by centralized useEffect
   };
-
-  // Metadata handlers - these don't trigger engine sync (no audio impact)
-  const handleTitleChange = useCallback((title: string) => {
-    const newGroove = { ...groove, title: title || undefined };
-    setGroove(newGroove);
-  }, [groove, setGroove]);
-
-  const handleAuthorChange = useCallback((author: string) => {
-    const newGroove = { ...groove, author: author || undefined };
-    setGroove(newGroove);
-  }, [groove, setGroove]);
-
-  const handleCommentsChange = useCallback((comments: string) => {
-    const newGroove = { ...groove, comments: comments || undefined };
-    setGroove(newGroove);
-  }, [groove, setGroove]);
 
   const handlePresetChange = (preset: GrooveData) => {
     setGroove(preset);

--- a/src/hooks/useGrooveActions.ts
+++ b/src/hooks/useGrooveActions.ts
@@ -1,0 +1,181 @@
+import { useCallback } from 'react';
+import { GrooveData, DrumVoice, createEmptyNotesRecord, MAX_MEASURES } from '../types';
+import { GrooveUtils } from '../core';
+
+/**
+ * A single note change for batch operations
+ */
+export interface NoteChange {
+  voice: DrumVoice;
+  position: number;
+  measureIndex: number;
+  value: boolean;
+}
+
+/**
+ * Actions returned by useGrooveActions hook
+ */
+export interface GrooveActions {
+  // Note manipulation
+  handleNoteToggle: (voice: DrumVoice, position: number, measureIndex: number) => void;
+  handleSetNotes: (changes: NoteChange[]) => void;
+  
+  // Measure manipulation
+  handleMeasureDuplicate: (measureIndex: number) => void;
+  handleMeasureAdd: (afterIndex: number) => void;
+  handleMeasureRemove: (measureIndex: number) => void;
+  handleMeasureClear: (measureIndex: number) => void;
+  handleClearAll: () => void;
+  
+  // Metadata
+  handleTitleChange: (title: string) => void;
+  handleAuthorChange: (author: string) => void;
+  handleCommentsChange: (comments: string) => void;
+}
+
+/**
+ * Hook for groove manipulation actions
+ * 
+ * Extracts shared business logic for note toggling, measure manipulation,
+ * and metadata updates. Used by both GrooveEditor and ProductionPage.
+ * 
+ * Engine sync is handled externally via centralized useEffect in the parent component.
+ */
+export function useGrooveActions(
+  groove: GrooveData,
+  setGroove: (groove: GrooveData) => void
+): GrooveActions {
+  
+  // Note toggle handler
+  const handleNoteToggle = useCallback((voice: DrumVoice, position: number, measureIndex: number) => {
+    const newMeasures = groove.measures.map((measure, idx) => {
+      if (idx !== measureIndex) return measure;
+      return {
+        ...measure,
+        notes: {
+          ...measure.notes,
+          [voice]: measure.notes[voice].map((note, i) => (i === position ? !note : note)),
+        },
+      };
+    });
+    const newGroove = { ...groove, measures: newMeasures };
+    setGroove(newGroove);
+  }, [groove, setGroove]);
+
+  // Batch set multiple notes at once (avoids React state batching issues)
+  const handleSetNotes = useCallback((changes: NoteChange[]) => {
+    const newMeasures = groove.measures.map((measure, measureIdx) => {
+      const measureChanges = changes.filter(c => c.measureIndex === measureIdx);
+      if (measureChanges.length === 0) return measure;
+
+      const newNotes = { ...measure.notes };
+      for (const change of measureChanges) {
+        newNotes[change.voice] = newNotes[change.voice].map((note, i) =>
+          i === change.position ? change.value : note
+        );
+      }
+      return { ...measure, notes: newNotes };
+    });
+    const newGroove = { ...groove, measures: newMeasures };
+    setGroove(newGroove);
+  }, [groove, setGroove]);
+
+  // Measure manipulation handlers
+  const handleMeasureDuplicate = useCallback((measureIndex: number) => {
+    if (groove.measures.length >= MAX_MEASURES) return;
+    const measureToCopy = groove.measures[measureIndex];
+    const copiedNotes = Object.fromEntries(
+      Object.entries(measureToCopy.notes).map(([voice, notes]) => [voice, [...notes]])
+    ) as typeof measureToCopy.notes;
+    const newMeasure = { ...measureToCopy, notes: copiedNotes };
+    const newMeasures = [
+      ...groove.measures.slice(0, measureIndex + 1),
+      newMeasure,
+      ...groove.measures.slice(measureIndex + 1),
+    ];
+    const newGroove = { ...groove, measures: newMeasures };
+    setGroove(newGroove);
+  }, [groove, setGroove]);
+
+  const handleMeasureAdd = useCallback((afterIndex: number) => {
+    if (groove.measures.length >= MAX_MEASURES) return;
+    const notesPerMeasure = GrooveUtils.calcNotesPerMeasure(
+      groove.division,
+      groove.timeSignature.beats,
+      groove.timeSignature.noteValue
+    );
+    const newMeasure = { notes: createEmptyNotesRecord(notesPerMeasure) };
+    const newMeasures = [
+      ...groove.measures.slice(0, afterIndex + 1),
+      newMeasure,
+      ...groove.measures.slice(afterIndex + 1),
+    ];
+    const newGroove = { ...groove, measures: newMeasures };
+    setGroove(newGroove);
+  }, [groove, setGroove]);
+
+  const handleMeasureRemove = useCallback((measureIndex: number) => {
+    if (groove.measures.length <= 1) return;
+    const newMeasures = groove.measures.filter((_, idx) => idx !== measureIndex);
+    const newGroove = { ...groove, measures: newMeasures };
+    setGroove(newGroove);
+  }, [groove, setGroove]);
+
+  const handleMeasureClear = useCallback((measureIndex: number) => {
+    const notesPerMeasure = GrooveUtils.calcNotesPerMeasure(
+      groove.division,
+      groove.timeSignature.beats,
+      groove.timeSignature.noteValue
+    );
+    const newMeasures = groove.measures.map((measure, idx) => {
+      if (idx !== measureIndex) return measure;
+      return { ...measure, notes: createEmptyNotesRecord(notesPerMeasure) };
+    });
+    const newGroove = { ...groove, measures: newMeasures };
+    setGroove(newGroove);
+  }, [groove, setGroove]);
+
+  const handleClearAll = useCallback(() => {
+    const notesPerMeasure = GrooveUtils.calcNotesPerMeasure(
+      groove.division,
+      groove.timeSignature.beats,
+      groove.timeSignature.noteValue
+    );
+    const newMeasures = groove.measures.map((measure) => ({
+      ...measure,
+      notes: createEmptyNotesRecord(notesPerMeasure),
+    }));
+    const newGroove = { ...groove, measures: newMeasures };
+    setGroove(newGroove);
+  }, [groove, setGroove]);
+
+  // Metadata handlers - these don't trigger engine sync (no audio impact)
+  const handleTitleChange = useCallback((title: string) => {
+    const newGroove = { ...groove, title: title || undefined };
+    setGroove(newGroove);
+  }, [groove, setGroove]);
+
+  const handleAuthorChange = useCallback((author: string) => {
+    const newGroove = { ...groove, author: author || undefined };
+    setGroove(newGroove);
+  }, [groove, setGroove]);
+
+  const handleCommentsChange = useCallback((comments: string) => {
+    const newGroove = { ...groove, comments: comments || undefined };
+    setGroove(newGroove);
+  }, [groove, setGroove]);
+
+  return {
+    handleNoteToggle,
+    handleSetNotes,
+    handleMeasureDuplicate,
+    handleMeasureAdd,
+    handleMeasureRemove,
+    handleMeasureClear,
+    handleClearAll,
+    handleTitleChange,
+    handleAuthorChange,
+    handleCommentsChange,
+  };
+}
+


### PR DESCRIPTION
## Summary

Extracts duplicate business logic from `GrooveEditor.tsx` and `ProductionPage.tsx` into a shared `useGrooveActions` hook.

## Changes

### New file: `src/hooks/useGrooveActions.ts`
- Creates a new hook with shared groove manipulation logic:
  - **Note manipulation**: `handleNoteToggle`, `handleSetNotes`
  - **Measure manipulation**: `handleMeasureDuplicate`, `handleMeasureAdd`, `handleMeasureRemove`, `handleMeasureClear`, `handleClearAll`
  - **Metadata updates**: `handleTitleChange`, `handleAuthorChange`, `handleCommentsChange`
- Exports `NoteChange` interface for batch note operations
- All handlers use `useCallback` for performance optimization

### Updated: `src/pages/ProductionPage.tsx`
- Removed ~90 lines of duplicate handler code
- Now imports and uses `useGrooveActions` hook

### Updated: `src/components/GrooveEditor.tsx`
- Removed ~100 lines of duplicate handler code
- Now imports and uses `useGrooveActions` hook

## Testing

- ✅ `npm run type-check` - passed
- ✅ `npm run build` - passed
- ✅ `npm test` - 50 tests passed

## Notes

- Engine sync is still handled by the centralized `useEffect` in each parent component (not moved to the hook) as per the existing architecture
- The hook follows the same patterns as other hooks in the codebase (`useHistory`, `useURLSync`, etc.)

Fixes #40

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author