### PR TITLE
refactor: code maintainability — split 7 large files into focused modules (#126–#132)

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -84,6 +84,7 @@ None currently. Ready to begin Phase 1 planning.
 | 260612-et2 | Migrate URL shortener client to publishable API key (#113) | 2026-06-12 | 8a6ce78 | [260612-et2-migrate-url-shortener-client-to-publisha](./quick/260612-et2-migrate-url-shortener-client-to-publisha/) |
 | 260614-fb9 | Make the URL shortener the default on the QR tab in ShareModal | 2026-06-14 | 9b6f1b1 | [260614-fb9-make-the-url-shortener-the-default-on-th](./quick/260614-fb9-make-the-url-shortener-the-default-on-th/) |
 | 260614-h0t | Per-tab default for the "Share as:" urlMode toggle in ShareModal | 2026-06-14 | acd89e5 | [260614-h0t-in-sharemodal-tsx-make-the-share-as-urlm](./quick/260614-h0t-in-sharemodal-tsx-make-the-share-as-urlm/) |
+| 260624-dy6 | Refactor ProductionPage.tsx: extract useModalState, useMeasureOperations, usePlaybackState, useStickingState hooks | 2026-06-24 | a3e5c85 | [260624-dy6-refactor-productionpage-tsx-extract-usem](./quick/260624-dy6-refactor-productionpage-tsx-extract-usem/) |
 
 ## Next Steps
 

--- a/.planning/quick/260624-dy6-refactor-productionpage-tsx-extract-usem/260624-dy6-PLAN.md
+++ b/.planning/quick/260624-dy6-refactor-productionpage-tsx-extract-usem/260624-dy6-PLAN.md
@@ -1,0 +1,49 @@
+---
+quick_id: 260624-dy6
+slug: refactor-productionpage-tsx-extract-usem
+description: "Refactor ProductionPage.tsx: extract useModalState, useMeasureOperations, usePlaybackState, useStickingState hooks"
+date: 2026-06-24
+status: in-progress
+---
+
+# Quick Task 260624-dy6: Refactor ProductionPage.tsx
+
+## Goal
+Reduce ProductionPage.tsx from 865 lines to ~430 lines by extracting four focused hooks.
+
+## Constraints
+- `findSimilarMeasures` and `applyStickingToSimilar` MUST remain exported from ProductionPage (imported by sticking.test.ts)
+- No API surface changes — JSX props stay identical
+- Run `npm test` after each extraction to catch regressions
+- No barrel index.ts needed (hooks imported directly already)
+
+## Tasks
+
+### Task 1: Extract useModalState
+**File:** `src/hooks/useModalState.ts`
+**Extract:** 7 modal open/close booleans (isDownloadModalOpen, isPrintModalOpen, isMyGroovesModalOpen, isSaveGrooveModalOpen, isGrooveLibraryModalOpen, isShareModalOpen, isTimeSignatureModalOpen)
+**Risk:** Very low — pure state, zero dependencies
+
+### Task 2: Extract useStickingState
+**File:** `src/hooks/useStickingState.ts`
+**Extract:** isStickingSetupActive, handleStickingSetupToggle, handleStickingChange, handleApplyToSimilar
+**Params:** (groove: GrooveData, setGroove: (g: GrooveData) => void)
+**Risk:** Low — depends only on groove/setGroove + applyStickingToSimilar (stays in ProductionPage)
+**Note:** handleApplyToSimilar references applyStickingToSimilar — import it in the hook
+
+### Task 3: Extract useMeasureCopyPaste
+**File:** `src/hooks/useMeasureCopyPaste.ts`
+**Extract:** copiedMeasureRef, cloneMeasure, handleMeasureCopy, handleMeasurePaste
+**Params:** (groove: GrooveData, setGroove: (g: GrooveData) => void)
+**Risk:** Low — self-contained clipboard logic
+
+### Task 4: Extract usePlaybackState
+**File:** `src/hooks/usePlaybackState.ts`
+**Extract:** elapsedTime, isCountingIn, countdownNumber, countingInButton, cancelCountIn, playCountIn, handlePlay, handlePlayWithSpeedUp
+**Params:** { groove, play, stop, isPlaying, metronomeConfig, autoSpeedUp, playPreview }
+**Risk:** Medium — most complex; handles count-in timing and analytics
+
+## Verification
+- npm test passes (239/239) before and after each extraction
+- ProductionPage.tsx line count drops from 865 to ~430
+- findSimilarMeasures and applyStickingToSimilar remain exported from ProductionPage

--- a/.planning/quick/260624-dy6-refactor-productionpage-tsx-extract-usem/260624-dy6-SUMMARY.md
+++ b/.planning/quick/260624-dy6-refactor-productionpage-tsx-extract-usem/260624-dy6-SUMMARY.md
@@ -1,0 +1,52 @@
+---
+quick_id: 260624-dy6
+status: complete
+date: 2026-06-24
+commit: a3e5c85
+---
+
+# Quick Task 260624-dy6 — Summary
+
+## Result
+
+Successfully extracted 4 custom hooks from ProductionPage.tsx, reducing it from **865 to 593 lines** (-272 lines, -31%).
+
+## Files Changed
+
+| File | Change | Lines |
+|------|--------|-------|
+| `src/pages/ProductionPage.tsx` | Modified (extractions applied) | 865 → 593 |
+| `src/hooks/useModalState.ts` | Created | 45 |
+| `src/hooks/useStickingState.ts` | Created | 76 |
+| `src/hooks/useMeasureCopyPaste.ts` | Created | 50 |
+| `src/hooks/usePlaybackState.ts` | Created | 163 |
+| `src/core/stickingUtils.ts` | Created (pure utils extracted) | 76 |
+
+## Hooks Extracted
+
+### useModalState
+Consolidates all 7 modal open/close boolean states. Zero dependencies beyond React.
+
+### useStickingState(groove, setGroove)
+Manages sticking setup mode, handleStickingChange, and handleApplyToSimilar.
+Imports applyStickingToSimilar from src/core/stickingUtils.ts (new file).
+
+### useMeasureCopyPaste(groove, setGroove)
+Handles measure clipboard operations with deep-copy clone logic.
+Includes the cloneMeasure helper (previously a useCallback in the component).
+
+### usePlaybackState({ groove, play, stop, isPlaying, metronomeConfig, autoSpeedUp, playPreview })
+Manages elapsed time tracking, count-in state and logic, handlePlay, handlePlayWithSpeedUp.
+Imports MetronomeConfig and DrumVoice from types.ts for proper typing.
+
+## Bonus: stickingUtils.ts
+
+Extracted findSimilarMeasures and applyStickingToSimilar as pure functions to
+src/core/stickingUtils.ts. ProductionPage re-exports them to preserve the import
+path used in src/__tests__/sticking.test.ts.
+
+## Test Results
+
+- **Before:** 22 test files, 239 tests passing
+- **After:** 22 test files, 239 tests passing ✅
+- TypeScript: clean (npx tsc --noEmit passes) ✅

--- a/src/components/production/DrumGridDark.tsx
+++ b/src/components/production/DrumGridDark.tsx
@@ -1,9 +1,10 @@
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Copy, Plus, Trash2, X, CopyCheck } from 'lucide-react';
 import { GrooveData, DrumVoice, MAX_MEASURES, StickingValue, createEmptySticking } from '../../types';
 import { GrooveUtils } from '../../core';
 import { useDrumGrid, DRUM_ROWS, NoteChange } from '../../hooks/useDrumGrid';
+import { useKeyboardEditor } from '../../hooks/useKeyboardEditor';
 import BulkOperationsDialog from '../BulkOperationsDialog';
 import NoteIcon from '../NoteIcon';
 import StickingRow from './StickingRow';
@@ -117,13 +118,6 @@ interface DrumGridDarkProps {
   onMeasurePaste?: (afterIndex: number) => boolean;
 }
 
-interface KeyboardCursor {
-  measureIndex: number;
-  rowIndex: number;
-  position: number;
-}
-
-const INITIAL_KEYBOARD_ROW_INDEX = Math.max(0, DRUM_ROWS.findIndex(row => row.name === 'Hi-Hat'));
 const KEYBOARD_HELP_TEXT = 'Keyboard editor. Space plays/pauses. Arrow keys move between cells. Enter toggles the default note. Tab opens variations. Shift or Alt with left and right arrows erases the adjacent cell. Control or Command with left and right arrows duplicates the current note. Control or Command C copies a measure. Control or Command V pastes it to the right.';
 
 export function DrumGridDark({
@@ -154,360 +148,25 @@ export function DrumGridDark({
     onStickingChange?.(measureIndex, subdivIndex, value);
   }, [onStickingChange]);
 
-  const [keyboardCursor, setKeyboardCursor] = useState<KeyboardCursor>({
-    measureIndex: 0,
-    rowIndex: INITIAL_KEYBOARD_ROW_INDEX,
-    position: 0,
-  });
-  const [keyboardVariationIndex, setKeyboardVariationIndex] = useState(0);
-  const [keyboardMessage, setKeyboardMessage] = useState<string | null>(null);
-  const cellRefs = useRef<Record<string, HTMLButtonElement | null>>({});
-  const keyboardMessageTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const getCellKey = useCallback((cursor: KeyboardCursor) => {
-    return `${cursor.measureIndex}-${cursor.rowIndex}-${cursor.position}`;
-  }, []);
-
-  const registerCellRef = useCallback((cursor: KeyboardCursor, element: HTMLButtonElement | null) => {
-    cellRefs.current[getCellKey(cursor)] = element;
-  }, [getCellKey]);
-
-  const getPositionCount = useCallback((measureIndex: number) => {
-    const measure = groove.measures[measureIndex];
-    const ts = measure?.timeSignature || groove.timeSignature;
-    return GrooveUtils.calcNotesPerMeasure(groove.division, ts.beats, ts.noteValue);
-  }, [groove.division, groove.measures, groove.timeSignature]);
-
-  const getHorizontalNeighbor = useCallback((cursor: KeyboardCursor, direction: -1 | 1): KeyboardCursor | null => {
-    const positionCount = getPositionCount(cursor.measureIndex);
-    const nextPosition = cursor.position + direction;
-
-    if (nextPosition >= 0 && nextPosition < positionCount) {
-      return { ...cursor, position: nextPosition };
-    }
-
-    const nextMeasureIndex = cursor.measureIndex + direction;
-    if (nextMeasureIndex < 0 || nextMeasureIndex >= groove.measures.length) {
-      return null;
-    }
-
-    return {
-      measureIndex: nextMeasureIndex,
-      rowIndex: cursor.rowIndex,
-      position: direction === 1 ? 0 : getPositionCount(nextMeasureIndex) - 1,
-    };
-  }, [getPositionCount, groove.measures.length]);
-
-  const moveKeyboardCursor = useCallback((direction: 'up' | 'down' | 'left' | 'right') => {
-    setKeyboardCursor(current => {
-      if (direction === 'left' || direction === 'right') {
-        return getHorizontalNeighbor(current, direction === 'right' ? 1 : -1) || current;
-      }
-
-      const nextRowIndex = Math.min(
-        DRUM_ROWS.length - 1,
-        Math.max(0, current.rowIndex + (direction === 'down' ? 1 : -1))
-      );
-
-      return { ...current, rowIndex: nextRowIndex };
-    });
-  }, [getHorizontalNeighbor]);
-
-  const getRowVoices = useCallback((cursor: KeyboardCursor) => {
-    const measure = groove.measures[cursor.measureIndex];
-    if (!measure) return [];
-    const row = DRUM_ROWS[cursor.rowIndex];
-    const activeVoices: DrumVoice[] = [];
-    row.variations.forEach(variation => {
-      variation.voices.forEach(voice => {
-        if (measure.notes[voice]?.[cursor.position] && !activeVoices.includes(voice)) {
-          activeVoices.push(voice);
-        }
-      });
-    });
-    return activeVoices;
-  }, [groove.measures]);
-
-  const setRowVoices = useCallback((cursor: KeyboardCursor, voices: DrumVoice[]) => {
-    const measure = groove.measures[cursor.measureIndex];
-    if (!measure) return;
-
-    const row = DRUM_ROWS[cursor.rowIndex];
-    const changes: NoteChange[] = [];
-
-    row.variations.forEach(variation => {
-      variation.voices.forEach(voice => {
-        if (measure.notes[voice]?.[cursor.position]) {
-          changes.push({
-            voice,
-            position: cursor.position,
-            measureIndex: cursor.measureIndex,
-            value: false,
-          });
-        }
-      });
-    });
-
-    voices.forEach(voice => {
-      changes.push({
-        voice,
-        position: cursor.position,
-        measureIndex: cursor.measureIndex,
-        value: true,
-      });
-    });
-
-    if (changes.length === 0) return;
-
-    if (onSetNotes) {
-      onSetNotes(changes);
-    } else {
-      changes.forEach(change => {
-        if (measure.notes[change.voice]?.[change.position] !== change.value) {
-          onNoteToggle(change.voice, change.position, change.measureIndex);
-        }
-      });
-    }
-
-    if (voices[0]) {
-      onPreview(voices[0]);
-    }
-  }, [groove.measures, onNoteToggle, onPreview, onSetNotes]);
-
-  const toggleKeyboardCell = useCallback(() => {
-    const activeVoices = getRowVoices(keyboardCursor);
-    setRowVoices(
-      keyboardCursor,
-      activeVoices.length > 0 ? [] : DRUM_ROWS[keyboardCursor.rowIndex].defaultVoices
-    );
-  }, [getRowVoices, keyboardCursor, setRowVoices]);
-
-  const duplicateKeyboardCell = useCallback((direction: -1 | 1) => {
-    const target = getHorizontalNeighbor(keyboardCursor, direction);
-    if (!target) return;
-
-    const sourceVoices = getRowVoices(keyboardCursor);
-    if (sourceVoices.length === 0) return;
-
-    setRowVoices(target, sourceVoices);
-    setKeyboardCursor(target);
-  }, [getHorizontalNeighbor, getRowVoices, keyboardCursor, setRowVoices]);
-
-  const eraseKeyboardCell = useCallback((direction: -1 | 1) => {
-    const target = getHorizontalNeighbor(keyboardCursor, direction);
-    if (!target) return;
-
-    setRowVoices(target, []);
-    setKeyboardCursor(target);
-  }, [getHorizontalNeighbor, keyboardCursor, setRowVoices]);
-
-  const openKeyboardVariationMenu = useCallback(() => {
-    const row = DRUM_ROWS[keyboardCursor.rowIndex];
-    if (row.variations.length <= 1) return;
-
-    const cell = cellRefs.current[getCellKey(keyboardCursor)];
-    if (!cell) return;
-
-    const rect = cell.getBoundingClientRect();
-    const menuWidth = 200;
-    const menuHeight = 34 + row.variations.length * 38 + 8;
-    const gap = 6;
-    const viewportPadding = 8;
-    const roomBelow = window.innerHeight - rect.bottom - gap - viewportPadding;
-    const roomAbove = rect.top - gap - viewportPadding;
-    const hasRoomBelow = roomBelow >= menuHeight;
-    const hasRoomAbove = roomAbove >= menuHeight;
-    const placement = hasRoomBelow || (!hasRoomAbove && roomBelow >= roomAbove) ? 'below' : 'above';
-    const selectedVoices = grid.getVoicesForPosition(
-      keyboardCursor.measureIndex,
-      keyboardCursor.rowIndex,
-      keyboardCursor.position
-    );
-    const selectedIndex = Math.max(0, row.variations.findIndex(variation =>
-      variation.voices.length === selectedVoices.length &&
-      variation.voices.every(voice => selectedVoices.includes(voice))
-    ));
-
-    setKeyboardVariationIndex(selectedIndex);
-    grid.setContextMenu({
-      visible: true,
-      x: Math.min(
-        Math.max(rect.left, viewportPadding),
-        window.innerWidth - menuWidth - viewportPadding
-      ),
-      y: placement === 'below'
-        ? rect.bottom + gap
-        : rect.top - menuHeight - gap,
-      placement,
-      rowIndex: keyboardCursor.rowIndex,
-      position: keyboardCursor.position,
-      measureIndex: keyboardCursor.measureIndex,
-    });
-  }, [getCellKey, grid, keyboardCursor]);
-
-  const handleKeyboardVariationSelect = useCallback((variationIndex: number) => {
-    const row = DRUM_ROWS[keyboardCursor.rowIndex];
-    const variation = row.variations[variationIndex];
-    if (!variation) return;
-
-    setKeyboardVariationIndex(variationIndex);
-    grid.handleVoiceSelect(variation.voices);
-  }, [grid, keyboardCursor.rowIndex]);
-
-  const isEditableTarget = useCallback((target: EventTarget | null) => {
-    if (!(target instanceof HTMLElement)) return false;
-    return Boolean(target.closest('input, textarea, select, [contenteditable="true"]'));
-  }, []);
-
-  const handleKeyboardEditKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (isEditableTarget(event.target)) return;
-
-    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'c') {
-      event.preventDefault();
-      onMeasureCopy?.(keyboardCursor.measureIndex);
-      return;
-    }
-
-    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'v') {
-      event.preventDefault();
-      const pasted = onMeasurePaste?.(keyboardCursor.measureIndex) ?? false;
-      if (pasted) {
-        setKeyboardMessage(null);
-        setKeyboardCursor(current => ({
-          ...current,
-          measureIndex: Math.min(current.measureIndex + 1, groove.measures.length),
-        }));
-      } else {
-        setKeyboardMessage(
-          groove.measures.length >= MAX_MEASURES
-            ? `Measure limit reached (${MAX_MEASURES}). Cannot paste more measures.`
-            : 'Copy a measure before pasting.'
-        );
-      }
-      return;
-    }
-
-    if (grid.contextMenu?.visible) {
-      const row = DRUM_ROWS[grid.contextMenu.rowIndex];
-      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-        event.preventDefault();
-        setKeyboardVariationIndex(current => {
-          const delta = event.key === 'ArrowDown' ? 1 : -1;
-          return (current + delta + row.variations.length) % row.variations.length;
-        });
-        return;
-      }
-
-      if (event.key === 'Enter') {
-        event.preventDefault();
-        handleKeyboardVariationSelect(keyboardVariationIndex);
-        return;
-      }
-
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        grid.setContextMenu(null);
-        return;
-      }
-    }
-
-    if (
-      (event.shiftKey || event.altKey) &&
-      (event.key === 'ArrowLeft' || event.key === 'ArrowRight')
-    ) {
-      event.preventDefault();
-      eraseKeyboardCell(event.key === 'ArrowRight' ? 1 : -1);
-      return;
-    }
-
-    if (
-      (event.ctrlKey || event.metaKey) &&
-      (event.key === 'ArrowLeft' || event.key === 'ArrowRight')
-    ) {
-      event.preventDefault();
-      duplicateKeyboardCell(event.key === 'ArrowRight' ? 1 : -1);
-      return;
-    }
-
-    if (event.key === 'ArrowLeft' || event.key === 'ArrowRight' || event.key === 'ArrowUp' || event.key === 'ArrowDown') {
-      event.preventDefault();
-      const direction = event.key.replace('Arrow', '').toLowerCase() as 'up' | 'down' | 'left' | 'right';
-      moveKeyboardCursor(direction);
-      return;
-    }
-
-    if (event.key === 'Enter') {
-      event.preventDefault();
-      toggleKeyboardCell();
-      return;
-    }
-
-    if (event.key === 'Tab') {
-      event.preventDefault();
-      openKeyboardVariationMenu();
-    }
-  }, [
-    duplicateKeyboardCell,
-    eraseKeyboardCell,
-    grid,
-    groove.measures.length,
-    handleKeyboardVariationSelect,
-    isEditableTarget,
+  const {
     keyboardCursor,
     keyboardVariationIndex,
-    moveKeyboardCursor,
+    keyboardMessage,
+    cellRefs,
+    getCellKey,
+    registerCellRef,
+    handleKeyboardEditKeyDown,
+    handleKeyboardVariationSelect,
+    setKeyboardCursor,
+  } = useKeyboardEditor({
+    groove,
+    grid,
+    onNoteToggle,
+    onSetNotes,
+    onPreview,
     onMeasureCopy,
     onMeasurePaste,
-    openKeyboardVariationMenu,
-    toggleKeyboardCell,
-  ]);
-
-  useEffect(() => {
-    setKeyboardCursor(current => {
-      const maxMeasureIndex = Math.max(0, groove.measures.length - 1);
-      const maxRowIndex = DRUM_ROWS.length - 1;
-
-      if (
-        current.measureIndex <= maxMeasureIndex &&
-        current.rowIndex <= maxRowIndex &&
-        current.position < getPositionCount(current.measureIndex)
-      ) {
-        return current;
-      }
-
-      const measureIndex = Math.min(current.measureIndex, maxMeasureIndex);
-      const position = Math.min(current.position, Math.max(0, getPositionCount(measureIndex) - 1));
-      const rowIndex = Math.min(current.rowIndex, maxRowIndex);
-      return { measureIndex, rowIndex, position };
-    });
-  }, [getPositionCount, groove.measures.length]);
-
-  useEffect(() => {
-    const cell = cellRefs.current[getCellKey(keyboardCursor)];
-    if (cell && document.activeElement?.closest('[data-keyboard-editor="true"]')) {
-      cell.focus({ preventScroll: true });
-      cell.scrollIntoView({ block: 'nearest', inline: 'nearest' });
-    }
-  }, [getCellKey, keyboardCursor]);
-
-  useEffect(() => {
-    if (!keyboardMessage) return;
-
-    if (keyboardMessageTimerRef.current) {
-      clearTimeout(keyboardMessageTimerRef.current);
-    }
-    keyboardMessageTimerRef.current = setTimeout(() => {
-      setKeyboardMessage(null);
-      keyboardMessageTimerRef.current = null;
-    }, 2500);
-
-    return () => {
-      if (keyboardMessageTimerRef.current) {
-        clearTimeout(keyboardMessageTimerRef.current);
-        keyboardMessageTimerRef.current = null;
-      }
-    };
-  }, [keyboardMessage]);
+  });
 
   // Per-measure transient notification for "Apply to Similar" feedback
   const [applyMessages, setApplyMessages] = useState<Record<number, string>>({});

--- a/src/core/GrooveEngine.ts
+++ b/src/core/GrooveEngine.ts
@@ -1,6 +1,7 @@
-import { GrooveData, DrumVoice, ALL_DRUM_VOICES, getFlattenedNotes, MetronomeFrequency, MetronomeOffsetClick, MetronomeConfig, DEFAULT_METRONOME_CONFIG } from '../types';
+import { GrooveData, DrumVoice, ALL_DRUM_VOICES, getFlattenedNotes, MetronomeFrequency, MetronomeOffsetClick, MetronomeConfig } from '../types';
 import { DrumSynth } from './DrumSynth';
 import { GrooveUtils } from './GrooveUtils';
+import { MetronomeManager } from './MetronomeManager';
 import { logger } from '../utils/logger';
 
 export type SyncMode = 'start' | 'middle' | 'end';
@@ -22,13 +23,9 @@ function calculateSwingOffset(
   _division: number,
   swing: number
 ): number {
-  // Swing only affects off-beat notes (odd positions in 16th notes)
   if (position % 2 === 0) {
     return 0;
   }
-  
-  // Off-beat notes: delay based on swing amount
-  // Convert swing percentage to ratio (0-100 -> 0-0.33)
   const swingRatio = (swing / 100) * 0.33;
   return swingRatio;
 }
@@ -48,9 +45,8 @@ export class GrooveEngine {
   private currentGroove: GrooveData | null = null;
   private pendingGroove: GrooveData | null = null;
   private loopEnabled = true;
-  private baseScheduleAheadTime = 0.15; // Base 150ms schedule-ahead time
+  private baseScheduleAheadTime = 0.15;
 
-  // Visual update state (RAF-based for performance)
   private visualRAFId: number | null = null;
   private lastEmittedPosition: number = -1;
 
@@ -58,188 +54,112 @@ export class GrooveEngine {
   // Shared with useMIDITracking so PerformanceTracker uses the same clock.
   private playStartPerformanceTime: number | null = null;
 
-  // Metronome state
-  private metronomeConfig: MetronomeConfig = { ...DEFAULT_METRONOME_CONFIG };
-  private currentRotationOffset = 0; // For ROTATE mode
-  private loopCount = 0; // Track loops for rotation
+  private readonly metronome = new MetronomeManager();
 
-  // Event listeners
   private listeners: Partial<GrooveEngineEvents> = {};
-  
+
   constructor(synth?: DrumSynth) {
     this.synth = synth || new DrumSynth();
   }
 
-  /**
-   * Get the synth instance for external use (e.g., MIDI input)
-   */
   getSynth(): DrumSynth {
     return this.synth;
   }
 
   /**
    * Get the performance.now() timestamp captured at the start of playback.
-   * Use this as the anchor for PerformanceTracker.enable() so MIDI hit
-   * timestamps (which use the same clock) align correctly.
    * Returns null when not playing or before the first play() call.
    */
   getPlayStartPerformanceTime(): number | null {
     return this.playStartPerformanceTime;
   }
 
-  /**
-   * Register event listeners
-   */
-  on<K extends keyof GrooveEngineEvents>(
-    event: K,
-    callback: GrooveEngineEvents[K]
-  ): void {
+  on<K extends keyof GrooveEngineEvents>(event: K, callback: GrooveEngineEvents[K]): void {
     this.listeners[event] = callback;
   }
-  
-  /**
-   * Remove event listener
-   */
+
   off<K extends keyof GrooveEngineEvents>(event: K): void {
     delete this.listeners[event];
   }
-  
-  /**
-   * Emit an event with proper type safety
-   */
+
   private emit<K extends keyof GrooveEngineEvents>(
     event: K,
     ...args: Parameters<GrooveEngineEvents[K]>
   ): void {
     const listener = this.listeners[event];
     if (listener) {
-      // Type assertion for callback function with proper parameter types
       (listener as (...callbackArgs: typeof args) => void)(...args);
     }
   }
-  
-  /**
-   * Set the sync mode for visual updates
-   */
+
   setSyncMode(mode: SyncMode): void {
     this.syncMode = mode;
   }
-  
-  /**
-   * Get current sync mode
-   */
+
   getSyncMode(): SyncMode {
     return this.syncMode;
   }
 
-  // ===== Metronome Methods =====
+  // ===== Metronome delegation =====
 
-  /**
-   * Set metronome frequency
-   */
   setMetronomeFrequency(frequency: MetronomeFrequency): void {
-    this.metronomeConfig.frequency = frequency;
+    this.metronome.setFrequency(frequency);
   }
 
-  /**
-   * Get metronome frequency
-   */
   getMetronomeFrequency(): MetronomeFrequency {
-    return this.metronomeConfig.frequency;
+    return this.metronome.getFrequency();
   }
 
-  /**
-   * Set metronome solo mode
-   */
   setMetronomeSolo(solo: boolean): void {
-    this.metronomeConfig.solo = solo;
+    this.metronome.setSolo(solo);
   }
 
-  /**
-   * Get metronome solo mode
-   */
   getMetronomeSolo(): boolean {
-    return this.metronomeConfig.solo;
+    return this.metronome.getSolo();
   }
 
-  /**
-   * Set metronome count-in
-   */
   setMetronomeCountIn(countIn: boolean): void {
-    this.metronomeConfig.countIn = countIn;
+    this.metronome.setCountIn(countIn);
   }
 
-  /**
-   * Get metronome count-in
-   */
   getMetronomeCountIn(): boolean {
-    return this.metronomeConfig.countIn;
+    return this.metronome.getCountIn();
   }
 
-  /**
-   * Set metronome offset click
-   */
   setMetronomeOffsetClick(offsetClick: MetronomeOffsetClick): void {
-    this.metronomeConfig.offsetClick = offsetClick;
-    this.currentRotationOffset = 0; // Reset rotation when manually setting
+    this.metronome.setOffsetClick(offsetClick);
   }
 
-  /**
-   * Get metronome offset click
-   */
   getMetronomeOffsetClick(): MetronomeOffsetClick {
-    return this.metronomeConfig.offsetClick;
+    return this.metronome.getOffsetClick();
   }
 
-  /**
-   * Set metronome volume (0-100)
-   */
   setMetronomeVolume(volume: number): void {
-    this.metronomeConfig.volume = Math.max(0, Math.min(100, volume));
+    this.metronome.setVolume(volume);
   }
 
-  /**
-   * Get metronome volume
-   */
   getMetronomeVolume(): number {
-    return this.metronomeConfig.volume;
+    return this.metronome.getVolume();
   }
 
-  /**
-   * Get full metronome config
-   */
   getMetronomeConfig(): MetronomeConfig {
-    return { ...this.metronomeConfig };
+    return this.metronome.getConfig();
   }
 
-  /**
-   * Set full metronome config
-   */
   setMetronomeConfig(config: Partial<MetronomeConfig>): void {
-    this.metronomeConfig = { ...this.metronomeConfig, ...config };
-    if (config.offsetClick !== undefined) {
-      this.currentRotationOffset = 0;
-    }
+    this.metronome.setConfig(config);
   }
 
-  // ===== End Metronome Methods =====
+  // ===== Volume =====
 
-  /**
-   * Set master volume (0-1)
-   */
   setMasterVolume(volume: number): void {
     const clampedVolume = Math.max(0, Math.min(1, volume));
     this.synth.setMasterVolume(clampedVolume);
   }
 
-  /**
-   * Get master volume
-   */
   getMasterVolume(): number {
     return this.synth.getMasterVolume();
   }
-
-  // ===== End Master Volume Methods =====
 
   /**
    * Update the groove during playback
@@ -247,10 +167,8 @@ export class GrooveEngine {
    * Validates division compatibility and auto-corrects if needed
    */
   updateGroove(groove: GrooveData): void {
-    // Build a corrected copy — never mutate the caller's object.
     let corrected: GrooveData = groove;
 
-    // Validate division compatibility with time signature
     if (!GrooveUtils.isDivisionCompatible(
       corrected.division,
       corrected.timeSignature.beats,
@@ -269,7 +187,6 @@ export class GrooveEngine {
       };
     }
 
-    // Auto-disable swing for triplets and quarter notes (check against possibly-corrected division)
     if (!GrooveUtils.doesDivisionSupportSwing(corrected.division)) {
       if (corrected.swing > 0) {
         logger.info(`Swing disabled for division ${corrected.division} (triplets/quarter notes don't support swing)`);
@@ -284,214 +201,81 @@ export class GrooveEngine {
       this.emit('grooveChange', corrected);
     }
   }
-  
-  /**
-   * Get current groove
-   */
+
   getCurrentGroove(): GrooveData | null {
     return this.currentGroove;
   }
-  
-  /**
-   * Check if there are pending changes
-   */
+
   hasPendingChanges(): boolean {
     return this.pendingGroove !== null;
   }
-  
-  /**
-   * Start playback
-   */
+
   async play(groove: GrooveData, loop: boolean = true): Promise<void> {
     await this.synth.resume();
 
-    if (this.isPlaying) {
-      return;
-    }
+    if (this.isPlaying) return;
 
     this.isPlaying = true;
     this.currentPosition = 0;
-    // Capture both the audio-context start time and the performance.now() anchor
-    // at the same instant so MIDI tracking can use the same clock reference.
     this.startTime = this.synth.getCurrentTime();
     this.playStartPerformanceTime = performance.now();
     this.currentGroove = groove;
     this.pendingGroove = null;
     this.loopEnabled = loop;
 
-    // Clear any stale end-stop timer from a previous non-loop session
     if (this.endStopTimerID !== null) {
       clearTimeout(this.endStopTimerID);
       this.endStopTimerID = null;
     }
 
-    // Reset metronome rotation state
-    this.loopCount = 0;
-    this.currentRotationOffset = 0;
-
+    this.metronome.resetRotation();
     this.emit('playbackStateChange', true);
 
-    // Start audio scheduling and visual update loops
     this.scheduleLoop();
     this.startVisualLoop();
   }
 
-  /**
-   * Check if a metronome click should play at the given position
-   * Returns 'accent' for beat 1, 'normal' for other beats, or null for no click
-   */
-  private shouldPlayMetronome(
-    positionInMeasure: number,
-    division: number,
-    timeSignature: { beats: number; noteValue: number },
-    notesPerMeasure: number
-  ): 'accent' | 'normal' | null {
-    const { frequency, offsetClick } = this.metronomeConfig;
-
-    if (frequency === 0) {
-      return null;
-    }
-
-    // Calculate positions per beat based on time signature
-    const positionsPerBeat = notesPerMeasure / timeSignature.beats;
-
-    // Calculate the metronome interval (how many positions between clicks)
-    // frequency is 4, 8, or 16 (notes per bar in 4/4)
-    // We need to convert this to positions based on current division
-    const metronomeDivision = frequency;
-    const clicksPerBeat = metronomeDivision / 4; // 4th=1, 8th=2, 16th=4 clicks per beat
-    const positionsPerClick = positionsPerBeat / clicksPerBeat;
-
-    // Determine the offset in positions based on offsetClick setting
-    let offsetPositions = 0;
-    const isTriplet = division === 12 || division === 24 || division === 48;
-
-    if (offsetClick === 'ROTATE') {
-      // In ROTATE mode, use the current rotation offset
-      const rotationOptions = isTriplet ? ['1', 'TI', 'TA'] : ['1', 'E', 'AND', 'A'];
-      const currentOffset = rotationOptions[this.currentRotationOffset % rotationOptions.length] as MetronomeOffsetClick;
-      offsetPositions = this.getOffsetPositions(currentOffset, positionsPerBeat, isTriplet);
-    } else {
-      offsetPositions = this.getOffsetPositions(offsetClick, positionsPerBeat, isTriplet);
-    }
-
-    // Check if this position should have a click
-    // First, shift the position by the offset
-    const adjustedPosition = (positionInMeasure - offsetPositions + notesPerMeasure) % notesPerMeasure;
-
-    // Check if this adjusted position falls on a click point
-    if (adjustedPosition % positionsPerClick !== 0) {
-      return null;
-    }
-
-    // Determine if this is beat 1 (accent) or other beat (normal)
-    // Beat 1 is when adjustedPosition is 0 (first click of the measure)
-    if (adjustedPosition === 0) {
-      return 'accent';
-    }
-
-    return 'normal';
-  }
-
-  /**
-   * Get offset positions for a given offset click setting
-   */
-  private getOffsetPositions(
-    offsetClick: MetronomeOffsetClick,
-    positionsPerBeat: number,
-    isTriplet: boolean
-  ): number {
-    if (isTriplet) {
-      switch (offsetClick) {
-        case 'TI':
-          return Math.floor(positionsPerBeat / 3); // Second triplet note
-        case 'TA':
-          return Math.floor((positionsPerBeat * 2) / 3); // Third triplet note
-        default:
-          return 0;
-      }
-    } else {
-      switch (offsetClick) {
-        case 'E':
-          return Math.floor(positionsPerBeat / 4); // Second 16th
-        case 'AND':
-          return Math.floor(positionsPerBeat / 2); // Second 8th
-        case 'A':
-          return Math.floor((positionsPerBeat * 3) / 4); // Fourth 16th
-        default:
-          return 0;
-      }
-    }
-  }
-
-  /**
-   * Main scheduling loop
-   */
   private scheduleLoop(): void {
-    if (!this.isPlaying) {
-      return;
-    }
+    if (!this.isPlaying) return;
 
     const currentTime = this.synth.getCurrentTime();
     const activeGroove = this.currentGroove!;
 
-    // Calculate note duration based on tempo and division
     const beatDuration = 60 / activeGroove.tempo;
     const noteDuration = beatDuration / (activeGroove.division / 4);
-
-    // Get total positions across all measures
     const totalPositions = GrooveUtils.getTotalPositions(activeGroove);
-
-    // Get flattened notes for multi-measure playback
     const flatNotes = getFlattenedNotes(activeGroove);
 
     // Adaptive schedule-ahead time: reduce at high tempos to reduce audio node accumulation
-    // Consider both tempo AND division (more notes = more nodes)
     let effectiveScheduleAheadTime = this.baseScheduleAheadTime;
     const notesPerSecond = (activeGroove.tempo * activeGroove.division) / (4 * 60);
 
     if (notesPerSecond > 32) {
-      // Very high note rate (e.g., 240 BPM / 1/8 or 180 BPM / 1/16)
-      effectiveScheduleAheadTime = 0.05; // 50ms - aggressive scheduling
+      effectiveScheduleAheadTime = 0.05;
     } else if (notesPerSecond > 24) {
-      // High note rate (e.g., 240 BPM / 1/16)
-      effectiveScheduleAheadTime = 0.065; // 65ms
+      effectiveScheduleAheadTime = 0.065;
     } else if (notesPerSecond > 16) {
-      // Moderate-high note rate
-      effectiveScheduleAheadTime = 0.08; // 80ms
+      effectiveScheduleAheadTime = 0.08;
     } else if (activeGroove.tempo > 180) {
-      effectiveScheduleAheadTime = 0.1; // 100ms for fast tempos
+      effectiveScheduleAheadTime = 0.1;
     } else if (activeGroove.tempo > 150) {
-      effectiveScheduleAheadTime = 0.12; // 120ms for moderate tempos
+      effectiveScheduleAheadTime = 0.12;
     }
 
-    // Schedule notes that should play in the next scheduleAheadTime window
     while (true) {
-      // Calculate absolute position within the full groove
       const absolutePosition = this.currentPosition % totalPositions;
-
-      // Calculate time for this position
       const noteTime = this.startTime + (this.currentPosition * noteDuration);
 
-      // Stop scheduling if we're too far ahead
-      if (noteTime > currentTime + effectiveScheduleAheadTime) {
-        break;
-      }
+      if (noteTime > currentTime + effectiveScheduleAheadTime) break;
 
-      // Get measure-relative position for swing calculation
       const { measureIndex, positionInMeasure } = GrooveUtils.absoluteToMeasurePosition(activeGroove, absolutePosition);
 
-      // Calculate swing offset
-      const swingOffset = calculateSwingOffset(
-        positionInMeasure,
-        activeGroove.division,
-        activeGroove.swing
-      );
-
+      const swingOffset = calculateSwingOffset(positionInMeasure, activeGroove.division, activeGroove.swing);
       const playTime = noteTime + (swingOffset * noteDuration);
 
-      // Schedule groove notes (unless solo mode is active)
-      if (!this.metronomeConfig.solo) {
+      const metronomeConfig = this.metronome.getConfig();
+
+      if (!metronomeConfig.solo) {
         ALL_DRUM_VOICES.forEach((voice) => {
           if (flatNotes[voice]?.[absolutePosition]) {
             this.synth.playDrum(voice, playTime - currentTime, 100);
@@ -499,8 +283,7 @@ export class GrooveEngine {
         });
       }
 
-      // Schedule metronome click if needed
-      if (this.metronomeConfig.frequency > 0) {
+      if (metronomeConfig.frequency > 0) {
         const measure = activeGroove.measures[measureIndex];
         const timeSignature = measure?.timeSignature || activeGroove.timeSignature;
         const notesPerMeasure = GrooveUtils.calcNotesPerMeasure(
@@ -509,7 +292,7 @@ export class GrooveEngine {
           timeSignature.noteValue
         );
 
-        const clickType = this.shouldPlayMetronome(
+        const clickType = this.metronome.shouldPlayClick(
           positionInMeasure,
           activeGroove.division,
           timeSignature,
@@ -520,21 +303,15 @@ export class GrooveEngine {
           const voice: DrumVoice = clickType === 'accent'
             ? 'hihat-metronome-accent'
             : 'hihat-metronome-normal';
-          // Convert metronome volume (0-100) to velocity (0-127)
-          const velocity = Math.round((this.metronomeConfig.volume / 100) * 127);
+          const velocity = Math.round((metronomeConfig.volume / 100) * 127);
           this.synth.playDrum(voice, playTime - currentTime, velocity);
         }
       }
 
-      // Visual updates are handled by RAF loop (startVisualLoop)
-
       this.currentPosition++;
 
-      // Check if we've completed a full loop through all measures
       if (absolutePosition === totalPositions - 1) {
         if (!this.loopEnabled) {
-          // Defer stop until the groove's full duration so the last scheduled note
-          // has time to play through before playbackStateChange(false) fires (P6).
           const grooveEndTime = this.startTime + totalPositions * noteDuration;
           const delayMs = Math.max(0, (grooveEndTime - currentTime) * 1000);
           if (this.endStopTimerID !== null) {
@@ -544,17 +321,8 @@ export class GrooveEngine {
           return;
         }
 
-        // Increment loop count and update rotation offset if in ROTATE mode
-        this.loopCount++;
-        if (this.metronomeConfig.offsetClick === 'ROTATE') {
-          const isTriplet = activeGroove.division === 12 ||
-                           activeGroove.division === 24 ||
-                           activeGroove.division === 48;
-          const rotationOptions = isTriplet ? 3 : 4;
-          this.currentRotationOffset = (this.currentRotationOffset + 1) % rotationOptions;
-        }
+        this.metronome.onLoopComplete(activeGroove.division);
 
-        // Apply pending groove changes at the end of the loop
         if (this.pendingGroove) {
           const nextLoopStartTime = this.startTime + (this.currentPosition * noteDuration);
           this.currentGroove = this.pendingGroove;
@@ -566,76 +334,50 @@ export class GrooveEngine {
       }
     }
 
-    // Schedule next check (50ms interval reduces CPU usage while maintaining timing accuracy)
     this.timerID = window.setTimeout(() => this.scheduleLoop(), 50);
   }
 
-  /**
-   * Start the RAF-based visual update loop
-   * Uses requestAnimationFrame for smooth 60fps visual updates
-   * instead of scheduling individual timeouts for each position
-   */
   private startVisualLoop(): void {
     const update = () => {
-      if (!this.isPlaying || !this.currentGroove) {
-        return;
-      }
+      if (!this.isPlaying || !this.currentGroove) return;
 
       const currentTime = this.synth.getCurrentTime();
       const groove = this.currentGroove;
 
-      // Calculate note duration
       const beatDuration = 60 / groove.tempo;
       const noteDuration = beatDuration / (groove.division / 4);
       const totalPositions = GrooveUtils.getTotalPositions(groove);
 
-      // Calculate elapsed time since playback started
       const elapsed = currentTime - this.startTime;
 
-      // Apply sync mode offset to visual timing
       let syncOffset = 0;
       switch (this.syncMode) {
-        case 'middle':
-          syncOffset = noteDuration / 2;
-          break;
-        case 'end':
-          syncOffset = noteDuration;
-          break;
-        // 'start' has no offset
+        case 'middle': syncOffset = noteDuration / 2; break;
+        case 'end': syncOffset = noteDuration; break;
       }
 
-      // Calculate current visual position
       const adjustedElapsed = elapsed + syncOffset;
       let visualPosition = Math.floor(adjustedElapsed / noteDuration);
 
-      // Handle looping - wrap position within total positions
       if (this.loopEnabled && visualPosition >= 0) {
         visualPosition = visualPosition % totalPositions;
       } else if (visualPosition >= totalPositions) {
-        // Non-looping mode and past end
         visualPosition = totalPositions - 1;
       }
 
-      // Clamp to valid range
       visualPosition = Math.max(0, Math.min(visualPosition, totalPositions - 1));
 
-      // Only emit if position changed
       if (visualPosition !== this.lastEmittedPosition) {
         this.lastEmittedPosition = visualPosition;
         this.emit('positionChange', visualPosition);
       }
 
-      // Continue the loop
       this.visualRAFId = requestAnimationFrame(update);
     };
 
-    // Start the RAF loop
     this.visualRAFId = requestAnimationFrame(update);
   }
 
-  /**
-   * Stop the RAF-based visual update loop
-   */
   private stopVisualLoop(): void {
     if (this.visualRAFId !== null) {
       cancelAnimationFrame(this.visualRAFId);
@@ -644,9 +386,6 @@ export class GrooveEngine {
     this.lastEmittedPosition = -1;
   }
 
-  /**
-   * Stop playback
-   */
   stop(): void {
     this.isPlaying = false;
     this.currentPosition = 0;
@@ -657,29 +396,21 @@ export class GrooveEngine {
       this.timerID = null;
     }
 
-    // Clear any pending deferred end-stop timer (non-loop mode)
     if (this.endStopTimerID !== null) {
       clearTimeout(this.endStopTimerID);
       this.endStopTimerID = null;
     }
 
-    // Stop visual update loop
     this.stopVisualLoop();
 
     this.emit('playbackStateChange', false);
     this.emit('positionChange', -1);
   }
 
-  /**
-   * Check if currently playing
-   */
   getIsPlaying(): boolean {
     return this.isPlaying;
   }
 
-  /**
-   * Get current tempo
-   */
   getTempo(): number {
     return this.currentGroove?.tempo ?? 120;
   }
@@ -691,52 +422,39 @@ export class GrooveEngine {
   setTempo(tempo: number): void {
     if (!this.currentGroove) return;
 
-    // Clamp tempo to valid range
     const clampedTempo = Math.max(30, Math.min(300, tempo));
 
     if (this.isPlaying) {
-      // Calculate current time offset before tempo change
       const currentTime = this.synth.getCurrentTime();
       const oldBeatDuration = 60 / this.currentGroove.tempo;
       const oldNoteDuration = oldBeatDuration / (this.currentGroove.division / 4);
       const elapsedTime = currentTime - this.startTime;
       const elapsedPositions = elapsedTime / oldNoteDuration;
 
-      // Update tempo
       this.currentGroove = { ...this.currentGroove, tempo: clampedTempo };
 
-      // Recalculate start time to maintain smooth transition
       const newBeatDuration = 60 / clampedTempo;
       const newNoteDuration = newBeatDuration / (this.currentGroove.division / 4);
       this.startTime = currentTime - (elapsedPositions * newNoteDuration);
 
-      // Also update pending groove if exists
       if (this.pendingGroove) {
         this.pendingGroove = { ...this.pendingGroove, tempo: clampedTempo };
       }
 
       this.emit('grooveChange', this.currentGroove);
     } else {
-      // Not playing - just update the groove
       this.currentGroove = { ...this.currentGroove, tempo: clampedTempo };
       this.emit('grooveChange', this.currentGroove);
     }
   }
 
-  /**
-   * Play a single drum hit (for preview)
-   */
   async playPreview(voice: DrumVoice): Promise<void> {
     await this.synth.resume();
     this.synth.playDrum(voice, 0, 100);
   }
 
-  /**
-   * Clean up resources
-   */
   dispose(): void {
     this.stop();
     this.listeners = {};
   }
 }
-

--- a/src/core/GrooveURLCodec.ts
+++ b/src/core/GrooveURLCodec.ts
@@ -8,7 +8,6 @@
  * ?TimeSig=4/4&Div=16&Tempo=120&Measures=1&H=|x-x-x-x-|&S=|----o---|&K=|o-------|
  */
 
-import { z } from 'zod';
 import {
   GrooveData,
   DrumVoice,
@@ -19,110 +18,23 @@ import {
   getFlattenedNotes,
 } from '../types';
 import { URL_TAB_CHARS, URL_VOICE_GROUPS } from './DrumVoiceConfig';
-
-/** Validation constraints for URL parameters */
-const VALIDATION = {
-  TEMPO: { MIN: 20, MAX: 400, DEFAULT: 120 },
-  SWING: { MIN: 0, MAX: 100, DEFAULT: 0 },
-  MEASURES: { MIN: 1, MAX: 32, DEFAULT: 1 },
-  BEATS: { MIN: 1, MAX: 16, DEFAULT: 4 },
-  TITLE_MAX_LENGTH: 200,
-  AUTHOR_MAX_LENGTH: 100,
-  COMMENTS_MAX_LENGTH: 1000,
-  PATTERN_MAX_LENGTH: 2000,
-  STICKING_MAX_LENGTH: 600, // 16 measures * 48 subdivisions max = 768, allow some headroom
-} as const;
-
-/**
- * Sticking encoding: maps StickingValue to a single URL-safe character.
- * null → '-', 'R' → 'r', 'L' → 'l', 'L/R' → 'b' (both)
- */
-const STICKING_ENCODE: Record<string, string> = {
-  'R': 'r',
-  'L': 'l',
-  'L/R': 'b',
-};
-const STICKING_DECODE: Record<string, StickingValue> = {
-  'r': 'R',
-  'l': 'L',
-  'b': 'L/R',
-};
-/** Valid decoded sticking characters (excluding rest '-') */
-const VALID_STICKING_CHARS = new Set(['r', 'l', 'b', '-']);
-
-/** Valid divisions - matches Division type in types.ts */
-const VALID_DIVISIONS = [4, 8, 12, 16, 24, 32, 48] as const;
-const VALID_NOTE_VALUES = [4, 8, 16] as const;
-
-/** Zod schema for time signature string (e.g., "4/4") */
-const timeSignatureSchema = z.string()
-  .regex(/^\d{1,2}\/\d{1,2}$/, 'Invalid time signature format')
-  .transform((str): { beats: number; noteValue: number } => {
-    const [beats, noteValue] = str.split('/').map(Number);
-    return { beats, noteValue };
-  })
-  .refine(
-    (ts) => ts.beats >= VALIDATION.BEATS.MIN && ts.beats <= VALIDATION.BEATS.MAX,
-    { message: `Beats must be between ${VALIDATION.BEATS.MIN} and ${VALIDATION.BEATS.MAX}` }
-  )
-  .refine(
-    (ts) => VALID_NOTE_VALUES.includes(ts.noteValue as 4 | 8 | 16),
-    { message: `Note value must be one of: ${VALID_NOTE_VALUES.join(', ')}` }
-  );
-
-/** Zod schema for division */
-const divisionSchema = z.coerce.number()
-  .refine(
-    (n) => VALID_DIVISIONS.includes(n as Division),
-    { message: `Division must be one of: ${VALID_DIVISIONS.join(', ')}` }
-  )
-  .transform((n) => n as Division);
-
-/** Zod schema for tempo */
-const tempoSchema = z.coerce.number()
-  .min(VALIDATION.TEMPO.MIN, `Tempo must be at least ${VALIDATION.TEMPO.MIN}`)
-  .max(VALIDATION.TEMPO.MAX, `Tempo must be at most ${VALIDATION.TEMPO.MAX}`)
-  .default(VALIDATION.TEMPO.DEFAULT);
-
-/** Zod schema for swing */
-const swingSchema = z.coerce.number()
-  .min(VALIDATION.SWING.MIN, `Swing must be at least ${VALIDATION.SWING.MIN}`)
-  .max(VALIDATION.SWING.MAX, `Swing must be at most ${VALIDATION.SWING.MAX}`)
-  .default(VALIDATION.SWING.DEFAULT);
-
-/** Zod schema for measures count */
-const measuresSchema = z.coerce.number()
-  .min(VALIDATION.MEASURES.MIN, `Measures must be at least ${VALIDATION.MEASURES.MIN}`)
-  .max(VALIDATION.MEASURES.MAX, `Measures must be at most ${VALIDATION.MEASURES.MAX}`)
-  .default(VALIDATION.MEASURES.DEFAULT);
-
-/** Zod schema for text fields (title, author, comments) */
-const titleSchema = z.string()
-  .max(VALIDATION.TITLE_MAX_LENGTH, `Title must be at most ${VALIDATION.TITLE_MAX_LENGTH} characters`)
-  .optional();
-
-const authorSchema = z.string()
-  .max(VALIDATION.AUTHOR_MAX_LENGTH, `Author must be at most ${VALIDATION.AUTHOR_MAX_LENGTH} characters`)
-  .optional();
-
-const commentsSchema = z.string()
-  .max(VALIDATION.COMMENTS_MAX_LENGTH, `Comments must be at most ${VALIDATION.COMMENTS_MAX_LENGTH} characters`)
-  .optional();
-
-/** Zod schema for voice patterns - validates format and length */
-const patternSchema = z.string()
-  .max(VALIDATION.PATTERN_MAX_LENGTH, `Pattern too long`)
-  .regex(/^[|a-zA-Z0-9\-+^]*$/, 'Invalid characters in pattern')
-  .optional();
-
-/**
- * Zod schema for sticking parameter — validates character set and length (T-02-07)
- * Valid chars: 'r', 'l', 'b', '-', '|'
- */
-const stickingParamSchema = z.string()
-  .max(VALIDATION.STICKING_MAX_LENGTH, 'Sticking parameter too long')
-  .regex(/^[rlb|-]*$/, 'Invalid characters in sticking parameter')
-  .optional();
+import {
+  VALIDATION,
+  MEASURE_SEP,
+  REST_CHAR,
+  timeSignatureSchema,
+  divisionSchema,
+  tempoSchema,
+  swingSchema,
+  measuresSchema,
+  titleSchema,
+  authorSchema,
+  commentsSchema,
+  patternSchema,
+  stickingParamSchema,
+  safeParse,
+} from './urlCodecSchemas';
+import { encodeStickingPattern, decodeStickingPattern } from './stickingCodec';
 
 /** URL parameter names */
 const PARAM = {
@@ -150,12 +62,6 @@ const PARAM = {
   STICKING: 'Stk',
 } as const;
 
-/** Rest character in URL patterns */
-const REST_CHAR = '-';
-
-/** Measure separator in URL patterns */
-const MEASURE_SEP = '|';
-
 /**
  * Voice groups for URL encoding/decoding
  * Imported from centralized DrumVoiceConfig
@@ -168,7 +74,6 @@ const VOICE_GROUPS = URL_VOICE_GROUPS as Record<string, DrumVoice[]>;
  * Special handling for hihat group: encodes both hihat-closed and hihat-foot if present
  */
 function encodeVoicePattern(groove: GrooveData, voices: DrumVoice[]): string {
-  // Guard against empty voices array
   if (voices.length === 0) {
     return '';
   }
@@ -190,11 +95,9 @@ function encodeVoicePattern(groove: GrooveData, voices: DrumVoice[]): string {
       const hasHihatFoot = canEncodeHihatFoot && measureNotes['hihat-foot']?.[i];
 
       // Special case: hihat group with both closed and foot at same position.
-      // A lone hihat-foot still falls through to its own URL char below.
       if (hasHihatClosed && hasHihatFoot) {
-        char = '^'; // Combination character for both
+        char = '^';
       } else {
-        // Check each voice in priority order, take first match
         for (const voice of voices) {
           if (measureNotes[voice]?.[i]) {
             char = URL_TAB_CHARS[voice] || REST_CHAR;
@@ -220,16 +123,13 @@ function decodeVoicePattern(
   voices: DrumVoice[],
   notesPerMeasure: number
 ): Partial<Record<DrumVoice, boolean[]>> {
-  // Remove measure separators and get characters
   const chars = pattern.replace(/\|/g, '').split('');
   const result: Partial<Record<DrumVoice, boolean[]>> = {};
 
-  // Initialize all voices with false
   for (const voice of voices) {
     result[voice] = Array(notesPerMeasure).fill(false);
   }
 
-  // Build reverse lookup: char → voice
   const charToVoice: Record<string, DrumVoice> = {};
   for (const voice of voices) {
     const char = URL_TAB_CHARS[voice];
@@ -238,11 +138,9 @@ function decodeVoicePattern(
     }
   }
 
-  // Decode each position
   for (let i = 0; i < Math.min(chars.length, notesPerMeasure); i++) {
     const char = chars[i];
     if (char === '^') {
-      // Special combination character: both hihat-closed and hihat-foot
       if (result['hihat-closed']) result['hihat-closed']![i] = true;
       if (result['hihat-foot']) result['hihat-foot']![i] = true;
     } else if (char !== REST_CHAR) {
@@ -257,105 +155,26 @@ function decodeVoicePattern(
 }
 
 /**
- * Encode sticking arrays from all measures into a single URL-safe string.
- * Format: |<measure1chars>|<measure2chars>|...
- * Characters: 'r'=R, 'l'=L, 'b'=L/R, '-'=null
- * Returns null if all sticking values are null (nothing to encode).
- */
-function encodeStickingPattern(groove: GrooveData): string | null {
-  const hasAnySticking = groove.measures.some(m =>
-    m.sticking && m.sticking.some(v => v !== null)
-  );
-  if (!hasAnySticking) return null;
-
-  const parts: string[] = [];
-  for (const measure of groove.measures) {
-    const sticking = measure.sticking;
-    if (!sticking || sticking.length === 0) {
-      // Determine length from notes array to produce correct-length placeholders
-      const firstVoice = Object.keys(measure.notes)[0] as DrumVoice | undefined;
-      const length = firstVoice ? (measure.notes[firstVoice]?.length ?? 0) : 0;
-      parts.push('-'.repeat(length));
-    } else {
-      parts.push(sticking.map(v => (v !== null ? STICKING_ENCODE[v] : '-')).join(''));
-    }
-  }
-
-  return MEASURE_SEP + parts.join(MEASURE_SEP) + MEASURE_SEP;
-}
-
-/**
- * Decode sticking URL parameter back to per-measure StickingValue arrays.
- * Validates each character (T-02-07). Invalid characters are treated as null.
- * Returns an array of sticking arrays (one per measure), or null if no sticking param.
- */
-function decodeStickingPattern(
-  param: string,
-  numMeasures: number,
-  notesPerMeasure: number
-): (StickingValue[] | undefined)[] {
-  // Trim exactly one leading/trailing MEASURE_SEP so that empty middle measures
-  // (empty string segments) keep their positional index and don't get shifted (C8).
-  const trimmed = param.startsWith(MEASURE_SEP) ? param.slice(1) : param;
-  const trimmed2 = trimmed.endsWith(MEASURE_SEP) ? trimmed.slice(0, -1) : trimmed;
-  const measurePatterns = trimmed2.split(MEASURE_SEP); // no .filter — preserve empty slots
-  const result: (StickingValue[] | undefined)[] = [];
-
-  for (let m = 0; m < numMeasures; m++) {
-    const chars = measurePatterns[m] ?? '';
-    if (chars.length === 0) {
-      result.push(undefined);
-      continue;
-    }
-    const sticking: StickingValue[] = [];
-    for (let i = 0; i < notesPerMeasure; i++) {
-      const ch = i < chars.length ? chars[i] : '-';
-      if (!VALID_STICKING_CHARS.has(ch)) {
-        // T-02-07: reject invalid sticking characters — treat as null
-        sticking.push(null);
-      } else {
-        sticking.push(STICKING_DECODE[ch] ?? null);
-      }
-    }
-    // Only return a sticking array if it has at least one non-null value
-    const hasValues = sticking.some(v => v !== null);
-    result.push(hasValues ? sticking : undefined);
-  }
-
-  return result;
-}
-
-/**
  * Encode GrooveData to URL search params string
  */
 export function encodeGrooveToURL(groove: GrooveData): string {
   const params = new URLSearchParams();
 
-  // Basic params
   params.set(PARAM.TIME_SIG, `${groove.timeSignature.beats}/${groove.timeSignature.noteValue}`);
   params.set(PARAM.DIV, String(groove.division));
   params.set(PARAM.TEMPO, String(groove.tempo));
   params.set(PARAM.MEASURES, String(groove.measures.length));
-  
+
   if (groove.swing > 0) {
     params.set(PARAM.SWING, String(groove.swing));
   }
 
-  // Metadata (only include if non-empty)
-  if (groove.title) {
-    params.set(PARAM.TITLE, groove.title);
-  }
-  if (groove.author) {
-    params.set(PARAM.AUTHOR, groove.author);
-  }
-  if (groove.comments) {
-    params.set(PARAM.COMMENTS, groove.comments);
-  }
+  if (groove.title) params.set(PARAM.TITLE, groove.title);
+  if (groove.author) params.set(PARAM.AUTHOR, groove.author);
+  if (groove.comments) params.set(PARAM.COMMENTS, groove.comments);
 
-  // Use flattened notes to check if any voice has notes
   const flatNotes = getFlattenedNotes(groove);
 
-  // Voice patterns
   for (const [param, voices] of Object.entries(VOICE_GROUPS)) {
     const hasNotes = voices.some((v: DrumVoice) => flatNotes[v]?.some((n: boolean) => n));
     if (hasNotes) {
@@ -363,28 +182,12 @@ export function encodeGrooveToURL(groove: GrooveData): string {
     }
   }
 
-  // Sticking (per D-08): only include if any sticking values are set
   const stickingEncoded = encodeStickingPattern(groove);
   if (stickingEncoded !== null) {
     params.set(PARAM.STICKING, stickingEncoded);
   }
 
   return params.toString();
-}
-
-/**
- * Safe parse helper - returns default value on validation failure
- */
-function safeParse<T>(
-  schema: z.ZodType<T>,
-  value: string | null | undefined,
-  defaultValue: T
-): T {
-  if (value === null || value === undefined) {
-    return defaultValue;
-  }
-  const result = schema.safeParse(value);
-  return result.success ? result.data : defaultValue;
 }
 
 /**
@@ -397,7 +200,6 @@ export function decodeURLToGroove(urlOrParams: string | URLSearchParams): Groove
     ? new URLSearchParams(urlOrParams.startsWith('?') ? urlOrParams.slice(1) : urlOrParams)
     : urlOrParams;
 
-  // Parse and validate basic params with Zod schemas
   const timeSigResult = timeSignatureSchema.safeParse(params.get(PARAM.TIME_SIG) || '4/4');
   const timeSignature: TimeSignature = timeSigResult.success
     ? { beats: timeSigResult.data.beats, noteValue: timeSigResult.data.noteValue as 4 | 8 | 16 }
@@ -408,7 +210,6 @@ export function decodeURLToGroove(urlOrParams: string | URLSearchParams): Groove
   const swing = safeParse(swingSchema, params.get(PARAM.SWING), VALIDATION.SWING.DEFAULT);
   const numMeasures = safeParse(measuresSchema, params.get(PARAM.MEASURES), VALIDATION.MEASURES.DEFAULT);
 
-  // Parse and validate metadata with length limits
   const title = safeParse(titleSchema, params.get(PARAM.TITLE), undefined);
   const author = safeParse(authorSchema, params.get(PARAM.AUTHOR), undefined);
   const comments = safeParse(commentsSchema, params.get(PARAM.COMMENTS), undefined);
@@ -417,23 +218,20 @@ export function decodeURLToGroove(urlOrParams: string | URLSearchParams): Groove
   // e.g., 4/4 with 16ths: (16/4) * 4 = 16
   const notesPerMeasure = (division / timeSignature.noteValue) * timeSignature.beats;
 
-  // Start with empty notes for each measure
   const measures: { notes: Record<DrumVoice, boolean[]>; sticking?: StickingValue[] }[] = [];
   for (let m = 0; m < numMeasures; m++) {
     measures.push({ notes: createEmptyNotesRecord(notesPerMeasure) });
   }
 
-  // Decode voice patterns with validation
   for (const [param, voices] of Object.entries(VOICE_GROUPS)) {
     const rawPattern = params.get(param);
-    // Validate pattern format before processing
     const pattern = safeParse(patternSchema, rawPattern, undefined);
     if (pattern) {
       // Trim exactly one leading/trailing MEASURE_SEP then split without filtering empties,
       // so that a future empty-middle-measure segment keeps its positional index (C8).
       const trimmed = pattern.startsWith(MEASURE_SEP) ? pattern.slice(1) : pattern;
       const trimmed2 = trimmed.endsWith(MEASURE_SEP) ? trimmed.slice(0, -1) : trimmed;
-      const measurePatterns = trimmed2.split(MEASURE_SEP); // no .filter — preserve empty slots
+      const measurePatterns = trimmed2.split(MEASURE_SEP);
 
       for (let m = 0; m < Math.min(measurePatterns.length, numMeasures); m++) {
         const decoded = decodeVoicePattern(
@@ -482,11 +280,8 @@ export function decodeURLToGroove(urlOrParams: string | URLSearchParams): Groove
  * - Error threshold: 8000 chars (likely to fail)
  */
 export const URL_LENGTH_LIMITS = {
-  /** Safe URL length for all browsers/servers */
   SAFE: 2000,
-  /** Warning threshold - consider compression */
   WARNING: 1500,
-  /** Maximum before likely failure */
   MAX: 8000,
 } as const;
 
@@ -540,10 +335,6 @@ export function validateURLLength(url: string): URLValidationResult {
  * in production deployments (e.g., /scribe/ or /groovy/).
  */
 export function getShareableURL(groove: GrooveData, baseURL?: string, mode: 'embed' | 'editor' = 'embed'): string {
-  // Use provided baseURL, or construct from origin + Vite's BASE_URL
-  // import.meta.env.BASE_URL is set by Vite based on the 'base' config:
-  // - Development: '/'
-  // - Production: '/scribe/' (or whatever PRODUCTION_BASE_PATH is set to)
   const base = baseURL || window.location.origin + (import.meta.env.BASE_URL || '/');
   const params = encodeGrooveToURL(groove);
   const url = `${base}?${params}`;
@@ -552,7 +343,6 @@ export function getShareableURL(groove: GrooveData, baseURL?: string, mode: 'emb
 
 /**
  * Get shareable URL with validation
- * Returns the URL along with validation status
  */
 export function getShareableURLWithValidation(
   groove: GrooveData,
@@ -594,6 +384,5 @@ export const GrooveURLCodec = {
   validateURLLength,
   hasGrooveParams,
   URL_LENGTH_LIMITS,
-  /** Validation constraints for URL parameters */
   VALIDATION,
 };

--- a/src/core/MetronomeManager.ts
+++ b/src/core/MetronomeManager.ts
@@ -1,0 +1,153 @@
+/**
+ * MetronomeManager - metronome state and click scheduling logic.
+ * Extracted from GrooveEngine.ts to isolate metronome concerns.
+ */
+
+import { MetronomeFrequency, MetronomeOffsetClick, MetronomeConfig, DEFAULT_METRONOME_CONFIG } from '../types';
+
+export class MetronomeManager {
+  private config: MetronomeConfig = { ...DEFAULT_METRONOME_CONFIG };
+  private currentRotationOffset = 0;
+  private loopCount = 0;
+
+  // ===== Config accessors =====
+
+  setFrequency(frequency: MetronomeFrequency): void {
+    this.config.frequency = frequency;
+  }
+
+  getFrequency(): MetronomeFrequency {
+    return this.config.frequency;
+  }
+
+  setSolo(solo: boolean): void {
+    this.config.solo = solo;
+  }
+
+  getSolo(): boolean {
+    return this.config.solo;
+  }
+
+  setCountIn(countIn: boolean): void {
+    this.config.countIn = countIn;
+  }
+
+  getCountIn(): boolean {
+    return this.config.countIn;
+  }
+
+  setOffsetClick(offsetClick: MetronomeOffsetClick): void {
+    this.config.offsetClick = offsetClick;
+    this.currentRotationOffset = 0;
+  }
+
+  getOffsetClick(): MetronomeOffsetClick {
+    return this.config.offsetClick;
+  }
+
+  setVolume(volume: number): void {
+    this.config.volume = Math.max(0, Math.min(100, volume));
+  }
+
+  getVolume(): number {
+    return this.config.volume;
+  }
+
+  getConfig(): MetronomeConfig {
+    return { ...this.config };
+  }
+
+  setConfig(config: Partial<MetronomeConfig>): void {
+    this.config = { ...this.config, ...config };
+    if (config.offsetClick !== undefined) {
+      this.currentRotationOffset = 0;
+    }
+  }
+
+  // ===== Playback lifecycle =====
+
+  /**
+   * Reset rotation state at the start of a new playback session.
+   */
+  resetRotation(): void {
+    this.loopCount = 0;
+    this.currentRotationOffset = 0;
+  }
+
+  /**
+   * Called at the end of each loop pass to advance ROTATE offset.
+   * @param division - Current groove division (to detect triplet vs straight)
+   */
+  onLoopComplete(division: number): void {
+    this.loopCount++;
+    if (this.config.offsetClick === 'ROTATE') {
+      const isTriplet = division === 12 || division === 24 || division === 48;
+      const rotationOptions = isTriplet ? 3 : 4;
+      this.currentRotationOffset = (this.currentRotationOffset + 1) % rotationOptions;
+    }
+  }
+
+  // ===== Click scheduling =====
+
+  /**
+   * Check if a metronome click should play at the given position.
+   * Returns 'accent' for beat 1, 'normal' for other beats, or null for no click.
+   */
+  shouldPlayClick(
+    positionInMeasure: number,
+    division: number,
+    timeSignature: { beats: number; noteValue: number },
+    notesPerMeasure: number
+  ): 'accent' | 'normal' | null {
+    const { frequency, offsetClick } = this.config;
+
+    if (frequency === 0) return null;
+
+    const positionsPerBeat = notesPerMeasure / timeSignature.beats;
+    const metronomeDivision = frequency;
+    const clicksPerBeat = metronomeDivision / 4;
+    const positionsPerClick = positionsPerBeat / clicksPerBeat;
+
+    let offsetPositions = 0;
+    const isTriplet = division === 12 || division === 24 || division === 48;
+
+    if (offsetClick === 'ROTATE') {
+      const rotationOptions = isTriplet ? ['1', 'TI', 'TA'] : ['1', 'E', 'AND', 'A'];
+      const currentOffset = rotationOptions[this.currentRotationOffset % rotationOptions.length] as MetronomeOffsetClick;
+      offsetPositions = this.getOffsetPositions(currentOffset, positionsPerBeat, isTriplet);
+    } else {
+      offsetPositions = this.getOffsetPositions(offsetClick, positionsPerBeat, isTriplet);
+    }
+
+    const adjustedPosition = (positionInMeasure - offsetPositions + notesPerMeasure) % notesPerMeasure;
+
+    if (adjustedPosition % positionsPerClick !== 0) return null;
+
+    return adjustedPosition === 0 ? 'accent' : 'normal';
+  }
+
+  /**
+   * Get offset positions for a given offset click setting.
+   * @private
+   */
+  private getOffsetPositions(
+    offsetClick: MetronomeOffsetClick,
+    positionsPerBeat: number,
+    isTriplet: boolean
+  ): number {
+    if (isTriplet) {
+      switch (offsetClick) {
+        case 'TI': return Math.floor(positionsPerBeat / 3);
+        case 'TA': return Math.floor((positionsPerBeat * 2) / 3);
+        default: return 0;
+      }
+    } else {
+      switch (offsetClick) {
+        case 'E': return Math.floor(positionsPerBeat / 4);
+        case 'AND': return Math.floor(positionsPerBeat / 2);
+        case 'A': return Math.floor((positionsPerBeat * 3) / 4);
+        default: return 0;
+      }
+    }
+  }
+}

--- a/src/core/exporters/exportAudio.ts
+++ b/src/core/exporters/exportAudio.ts
@@ -1,0 +1,189 @@
+import { GrooveData, DrumVoice, ALL_DRUM_VOICES, getFlattenedNotes } from '../../types';
+import { GrooveUtils } from '../GrooveUtils';
+import { DRUM_VOICE_TO_MIDI, getVelocityForVoice } from '../DrumVoiceConfig';
+import { AudioExportOptions, generateFilename, triggerDownload, getMidiWriter, getMp3Encoder } from './helpers';
+
+export const DRUM_SAMPLE_FILES: Record<DrumVoice, string> = {
+  'hihat-closed': 'Hi Hat Normal.mp3',
+  'hihat-open': 'Hi Hat Open.mp3',
+  'hihat-accent': 'Hi Hat Accent.mp3',
+  'hihat-foot': 'Hi Hat Foot.mp3',
+  'hihat-metronome-normal': 'metronomeClick.mp3',
+  'hihat-metronome-accent': 'metronome1Count.mp3',
+  'hihat-cross': 'Hi Hat Normal.mp3',
+  'snare-normal': 'Snare Normal.mp3',
+  'snare-accent': 'Snare Accent.mp3',
+  'snare-ghost': 'Snare Ghost.mp3',
+  'snare-cross-stick': 'Snare Cross Stick.mp3',
+  'snare-flam': 'Snare Flam.mp3',
+  'snare-rim': 'Rim.mp3',
+  'snare-drag': 'Drag.mp3',
+  'snare-buzz': 'Buzz.mp3',
+  kick: 'Kick.mp3',
+  'tom-rack': 'Rack Tom.mp3',
+  'tom-floor': 'Floor Tom.mp3',
+  'tom-10': '10 Tom.mp3',
+  'tom-16': '16 Tom.mp3',
+  crash: 'Crash.mp3',
+  ride: 'Ride.mp3',
+  'ride-bell': 'Bell.mp3',
+  cowbell: 'Cowbell.mp3',
+  stacker: 'Stacker.mp3',
+};
+
+export async function exportToMIDI(groove: GrooveData, options: AudioExportOptions = {}): Promise<Blob> {
+  const { loops = 1 } = options;
+
+  const MidiWriter = await getMidiWriter();
+
+  const track = new MidiWriter.Track();
+  track.setTempo(groove.tempo);
+  track.setTimeSignature(groove.timeSignature.beats, groove.timeSignature.noteValue, 24, 8);
+
+  const ticksPerBeat = 128;
+  const ticksPerSubdivision = (ticksPerBeat * 4) / groove.division;
+
+  const flatNotes = getFlattenedNotes(groove);
+  const totalPositions = GrooveUtils.getTotalPositions(groove);
+
+  for (let loop = 0; loop < loops; loop++) {
+    for (let pos = 0; pos < totalPositions; pos++) {
+      const absoluteTick = (loop * totalPositions + pos) * ticksPerSubdivision;
+
+      ALL_DRUM_VOICES.forEach((voice) => {
+        if (flatNotes[voice]?.[pos]) {
+          if (voice.includes('metronome')) return;
+
+          const midiNote = DRUM_VOICE_TO_MIDI[voice];
+          const velocity = getVelocityForVoice(voice);
+
+          track.addEvent(
+            new MidiWriter.NoteEvent({
+              pitch: [midiNote],
+              duration: 'T' + ticksPerSubdivision,
+              velocity: velocity,
+              startTick: absoluteTick,
+              channel: 10,
+            })
+          );
+        }
+      });
+    }
+  }
+
+  const writer = new MidiWriter.Writer([track]);
+  const midiData = writer.buildFile();
+
+  return new Blob([midiData], { type: 'audio/midi' });
+}
+
+export async function downloadAsMIDI(groove: GrooveData, options: AudioExportOptions = {}): Promise<void> {
+  const blob = await exportToMIDI(groove, options);
+  triggerDownload(blob, generateFilename(groove, 'midi'));
+}
+
+async function loadSamplesForOffline(offlineCtx: OfflineAudioContext): Promise<Map<DrumVoice, AudioBuffer>> {
+  const samples = new Map<DrumVoice, AudioBuffer>();
+  const basePath = import.meta.env.BASE_URL || '/';
+
+  await Promise.all(
+    ALL_DRUM_VOICES.map(async (voice) => {
+      if (voice.includes('metronome')) return;
+
+      const soundPath = `${basePath}sounds/${DRUM_SAMPLE_FILES[voice]}`;
+
+      try {
+        const response = await fetch(soundPath);
+        if (!response.ok) return;
+
+        const arrayBuffer = await response.arrayBuffer();
+        const audioBuffer = await offlineCtx.decodeAudioData(arrayBuffer);
+        samples.set(voice, audioBuffer);
+      } catch {
+        console.warn(`Failed to load sample for ${voice}`);
+      }
+    })
+  );
+
+  return samples;
+}
+
+export async function exportToMP3(groove: GrooveData, options: AudioExportOptions = {}): Promise<Blob> {
+  const { loops = 1 } = options;
+
+  const beatDuration = 60 / groove.tempo;
+  const noteDuration = beatDuration / (groove.division / 4);
+  const totalPositions = GrooveUtils.getTotalPositions(groove);
+  const loopDuration = totalPositions * noteDuration;
+  const totalDuration = loopDuration * loops + 2;
+
+  const sampleRate = 44100;
+  const offlineCtx = new OfflineAudioContext(2, sampleRate * totalDuration, sampleRate);
+
+  const samples = await loadSamplesForOffline(offlineCtx);
+  const flatNotes = getFlattenedNotes(groove);
+
+  for (let loop = 0; loop < loops; loop++) {
+    for (let pos = 0; pos < totalPositions; pos++) {
+      const time = (loop * totalPositions + pos) * noteDuration;
+
+      ALL_DRUM_VOICES.forEach((voice) => {
+        if (flatNotes[voice]?.[pos] && !voice.includes('metronome')) {
+          const sample = samples.get(voice);
+          if (!sample) return;
+
+          const source = offlineCtx.createBufferSource();
+          source.buffer = sample;
+
+          const gainNode = offlineCtx.createGain();
+          gainNode.gain.value = getVelocityForVoice(voice) / 127;
+
+          source.connect(gainNode);
+          gainNode.connect(offlineCtx.destination);
+          source.start(time);
+        }
+      });
+    }
+  }
+
+  const renderedBuffer = await offlineCtx.startRendering();
+
+  const Mp3Encoder = await getMp3Encoder();
+  const mp3encoder = new Mp3Encoder(2, sampleRate, 128);
+
+  const leftChannel = renderedBuffer.getChannelData(0);
+  const rightChannel = renderedBuffer.getChannelData(1);
+
+  const sampleBlockSize = 1152;
+  const mp3Data: Uint8Array[] = [];
+
+  for (let i = 0; i < leftChannel.length; i += sampleBlockSize) {
+    const leftChunk = leftChannel.subarray(i, i + sampleBlockSize);
+    const rightChunk = rightChannel.subarray(i, i + sampleBlockSize);
+
+    const leftInt16 = new Int16Array(leftChunk.length);
+    const rightInt16 = new Int16Array(rightChunk.length);
+
+    for (let j = 0; j < leftChunk.length; j++) {
+      leftInt16[j] = Math.max(-32768, Math.min(32767, leftChunk[j] * 32767));
+      rightInt16[j] = Math.max(-32768, Math.min(32767, rightChunk[j] * 32767));
+    }
+
+    const mp3buf = mp3encoder.encodeBuffer(leftInt16, rightInt16);
+    if (mp3buf.length > 0) {
+      mp3Data.push(mp3buf);
+    }
+  }
+
+  const mp3buf = mp3encoder.flush();
+  if (mp3buf.length > 0) {
+    mp3Data.push(mp3buf);
+  }
+
+  return new Blob(mp3Data, { type: 'audio/mp3' });
+}
+
+export async function downloadAsMP3(groove: GrooveData, options: AudioExportOptions = {}): Promise<void> {
+  const blob = await exportToMP3(groove, options);
+  triggerDownload(blob, generateFilename(groove, 'mp3'));
+}

--- a/src/core/exporters/exportImage.ts
+++ b/src/core/exporters/exportImage.ts
@@ -1,0 +1,283 @@
+import { GrooveData } from '../../types';
+import { grooveToABC } from '../ABCTranscoder';
+import { renderABC } from '../ABCRenderer';
+import { hasVisibleStickings, layoutStickingAndCountRows } from '../SVGAnnotationLayout';
+import { getShareableURL } from '../GrooveURLCodec';
+import { ExportProgress, ImageExportOptions, yieldToMain, sanitizeSVG, escapeXml, generateFilename, triggerDownload, getQRCode, getJsPDF } from './helpers';
+
+function renderSheetMusicToSVG(groove: GrooveData, width: number): string {
+  const container = document.createElement('div');
+  container.style.position = 'absolute';
+  container.style.left = '-9999px';
+  container.style.width = `${width}px`;
+  document.body.appendChild(container);
+
+  try {
+    const abc = grooveToABC(groove, { title: undefined });
+    renderABC(abc, container, {
+      staffWidth: width - 40,
+      scale: 1.0,
+      responsive: false,
+      padding: 20,
+      paddingTop: hasVisibleStickings(groove) ? 46 : 20,
+      foregroundColor: '#000000',
+    });
+
+    const svgElement = container.querySelector('svg');
+    if (!svgElement) {
+      throw new Error('Failed to generate SVG');
+    }
+    layoutStickingAndCountRows(svgElement, groove);
+
+    return sanitizeSVG(svgElement.outerHTML);
+  } finally {
+    document.body.removeChild(container);
+  }
+}
+
+export async function generateSheetMusicSVG(
+  groove: GrooveData,
+  options: ImageExportOptions = {},
+  onProgress?: (progress: ExportProgress) => void
+): Promise<string> {
+  const { width = 800 } = options;
+
+  onProgress?.({ stage: 'preparing', percent: 0, message: 'Preparing export...' });
+  await yieldToMain();
+
+  const shareableURL = getShareableURL(groove, undefined, 'embed');
+
+  onProgress?.({ stage: 'generating', percent: 20, message: 'Generating sheet music...' });
+  await yieldToMain();
+
+  const sheetMusicSVG = renderSheetMusicToSVG(groove, width);
+
+  onProgress?.({ stage: 'rendering', percent: 50, message: 'Creating QR code...' });
+  await yieldToMain();
+
+  const QRCode = await getQRCode();
+  const qrDataURL = await QRCode.toDataURL(shareableURL, {
+    width: 64,
+    margin: 0,
+    color: { dark: '#000000', light: '#ffffff' },
+  });
+
+  onProgress?.({ stage: 'finalizing', percent: 80, message: 'Finalizing SVG...' });
+  await yieldToMain();
+
+  const parser = new DOMParser();
+  const sheetDoc = parser.parseFromString(sheetMusicSVG, 'image/svg+xml');
+  const sheetSvg = sheetDoc.querySelector('svg');
+  const sheetHeight = sheetSvg ? parseFloat(sheetSvg.getAttribute('height') || '200') : 200;
+
+  const headerHeight = 60;
+  const footerHeight = 90;
+  const padding = 20;
+  const totalHeight = headerHeight + sheetHeight + footerHeight + padding * 2;
+
+  const metaItems = [
+    `Tempo: ${groove.tempo} BPM`,
+    `Time: ${groove.timeSignature.beats}/${groove.timeSignature.noteValue}`,
+    `Measures: ${groove.measures.length}`,
+  ];
+  if (groove.author) metaItems.push(`Author: ${groove.author}`);
+
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="${width}" height="${totalHeight}" viewBox="0 0 ${width} ${totalHeight}">
+  <defs>
+    <style>
+      .title { font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 24px; font-weight: 700; fill: #1e293b; }
+      .meta { font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; fill: #64748b; }
+      .url { font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 10px; fill: #64748b; }
+      .branding { font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; fill: #94a3b8; }
+      .divider { stroke: #e2e8f0; stroke-width: 1; }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="100%" height="100%" fill="white"/>
+
+  <!-- Header -->
+  <text x="${padding}" y="${padding + 24}" class="title">${escapeXml(groove.title || 'Untitled Groove')}</text>
+  <text x="${padding}" y="${padding + 45}" class="meta">${metaItems.join('  •  ')}</text>
+  <line x1="${padding}" y1="${headerHeight}" x2="${width - padding}" y2="${headerHeight}" class="divider"/>
+
+  <!-- Sheet Music -->
+  <g transform="translate(0, ${headerHeight})">
+    ${sheetMusicSVG.replace(/<\?xml[^?]*\?>/, '').replace(/^<svg[^>]*>/, '').replace(/<\/svg>$/, '')}
+  </g>
+
+  <!-- Footer -->
+  <line x1="${padding}" y1="${headerHeight + sheetHeight + padding}" x2="${width - padding}" y2="${headerHeight + sheetHeight + padding}" class="divider"/>
+  <g transform="translate(${padding}, ${headerHeight + sheetHeight + padding + 10})">
+    <!-- QR Code -->
+    <image x="0" y="0" width="64" height="64" xlink:href="${qrDataURL}"/>
+    <!-- URL Text -->
+    <text x="80" y="20" class="url">${escapeXml(shareableURL.substring(0, 80))}</text>
+    ${shareableURL.length > 80 ? `<text x="80" y="35" class="url">${escapeXml(shareableURL.substring(80, 160))}</text>` : ''}
+    <!-- Branding -->
+    <text x="${width - padding * 2 - 120}" y="40" class="branding">Created with Groovy</text>
+  </g>
+</svg>`;
+
+  onProgress?.({ stage: 'finalizing', percent: 100, message: 'Complete!' });
+
+  return svg;
+}
+
+export async function exportToSVG(groove: GrooveData, options: ImageExportOptions = {}): Promise<Blob> {
+  const svgString = await generateSheetMusicSVG(groove, options);
+  return new Blob([svgString], { type: 'image/svg+xml' });
+}
+
+export async function downloadAsSVG(groove: GrooveData, options: ImageExportOptions = {}): Promise<void> {
+  const blob = await exportToSVG(groove, options);
+  triggerDownload(blob, generateFilename(groove, 'svg'));
+}
+
+export async function exportToPNG(
+  groove: GrooveData,
+  options: ImageExportOptions = {},
+  onProgress?: (progress: ExportProgress) => void
+): Promise<Blob> {
+  const { backgroundColor = '#ffffff' } = options;
+
+  onProgress?.({ stage: 'generating', percent: 0, message: 'Generating SVG...' });
+  const svgString = await generateSheetMusicSVG(groove, options, onProgress);
+
+  onProgress?.({ stage: 'encoding', percent: 70, message: 'Converting to PNG...' });
+  await yieldToMain();
+
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const svgBlob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
+    const url = URL.createObjectURL(svgBlob);
+
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      const scale = 2;
+      canvas.width = img.width * scale;
+      canvas.height = img.height * scale;
+
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        URL.revokeObjectURL(url);
+        reject(new Error('Failed to get canvas context'));
+        return;
+      }
+
+      ctx.fillStyle = backgroundColor;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.scale(scale, scale);
+      ctx.drawImage(img, 0, 0);
+
+      URL.revokeObjectURL(url);
+
+      canvas.toBlob(
+        (blob) => {
+          if (blob) {
+            onProgress?.({ stage: 'finalizing', percent: 100, message: 'Complete!' });
+            resolve(blob);
+          } else {
+            reject(new Error('Failed to create PNG blob'));
+          }
+        },
+        'image/png',
+        1.0
+      );
+    };
+
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('Failed to load SVG for PNG conversion'));
+    };
+
+    img.src = url;
+  });
+}
+
+export async function downloadAsPNG(groove: GrooveData, options: ImageExportOptions = {}): Promise<void> {
+  const blob = await exportToPNG(groove, options);
+  triggerDownload(blob, generateFilename(groove, 'png'));
+}
+
+export async function exportToPDF(
+  groove: GrooveData,
+  options: ImageExportOptions = {},
+  onProgress?: (progress: ExportProgress) => void
+): Promise<Blob> {
+  onProgress?.({ stage: 'generating', percent: 0, message: 'Generating SVG...' });
+
+  const svgString = await generateSheetMusicSVG(groove, options, onProgress);
+
+  onProgress?.({ stage: 'rendering', percent: 60, message: 'Loading PDF library...' });
+  await yieldToMain();
+
+  const jsPDF = await getJsPDF();
+
+  const pdf = new jsPDF({
+    orientation: 'landscape',
+    unit: 'pt',
+    format: 'a4',
+  });
+
+  const pageWidth = pdf.internal.pageSize.getWidth();
+  const pageHeight = pdf.internal.pageSize.getHeight();
+  const margin = 30;
+
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const svgBlob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
+    const url = URL.createObjectURL(svgBlob);
+
+    img.onload = () => {
+      const availableWidth = pageWidth - margin * 2;
+      const availableHeight = pageHeight - margin * 2;
+      const scale = Math.min(availableWidth / img.width, availableHeight / img.height, 1.5);
+      const imgWidth = img.width * scale;
+      const imgHeight = img.height * scale;
+
+      const xPos = (pageWidth - imgWidth) / 2;
+      const yPos = (pageHeight - imgHeight) / 2;
+
+      const canvas = document.createElement('canvas');
+      canvas.width = img.width * 2;
+      canvas.height = img.height * 2;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        URL.revokeObjectURL(url);
+        reject(new Error('Failed to get canvas context'));
+        return;
+      }
+
+      ctx.fillStyle = '#ffffff';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.scale(2, 2);
+      ctx.drawImage(img, 0, 0);
+
+      URL.revokeObjectURL(url);
+
+      onProgress?.({ stage: 'encoding', percent: 80, message: 'Creating PDF...' });
+
+      const imgData = canvas.toDataURL('image/png');
+      pdf.addImage(imgData, 'PNG', xPos, yPos, imgWidth, imgHeight);
+
+      const pdfBlob = pdf.output('blob');
+      onProgress?.({ stage: 'finalizing', percent: 100, message: 'Complete!' });
+      resolve(pdfBlob);
+    };
+
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('Failed to load SVG for PDF conversion'));
+    };
+
+    img.src = url;
+  });
+}
+
+export async function downloadAsPDF(groove: GrooveData, options: ImageExportOptions = {}): Promise<void> {
+  const blob = await exportToPDF(groove, options);
+  triggerDownload(blob, generateFilename(groove, 'pdf'));
+}

--- a/src/core/exporters/exportJSON.ts
+++ b/src/core/exporters/exportJSON.ts
@@ -1,0 +1,27 @@
+import { GrooveData } from '../../types';
+import { ExportMetadata, JSONExportOptions, generateFilename, triggerDownload } from './helpers';
+
+export function exportToJSON(groove: GrooveData, options: JSONExportOptions = {}): Blob {
+  const { includeMetadata = true, prettyPrint = true } = options;
+
+  const exportData: { groove: GrooveData; metadata?: ExportMetadata } = { groove };
+
+  if (includeMetadata) {
+    exportData.metadata = {
+      version: '1.0.0',
+      exportedAt: new Date().toISOString(),
+      appName: 'Groovy',
+    };
+  }
+
+  const jsonString = prettyPrint
+    ? JSON.stringify(exportData, null, 2)
+    : JSON.stringify(exportData);
+
+  return new Blob([jsonString], { type: 'application/json' });
+}
+
+export function downloadAsJSON(groove: GrooveData, options: JSONExportOptions = {}): void {
+  const blob = exportToJSON(groove, options);
+  triggerDownload(blob, generateFilename(groove, 'json'));
+}

--- a/src/core/exporters/helpers.ts
+++ b/src/core/exporters/helpers.ts
@@ -1,0 +1,193 @@
+/**
+ * Shared helpers for export modules:
+ * progress types, lazy-loader caches, yieldToMain, sanitizeSVG, escapeXml,
+ * generateFilename, triggerDownload, isFormatSupported, getFormatInfo, ALL_EXPORT_FORMATS.
+ */
+
+import DOMPurify from 'dompurify';
+import { GrooveData } from '../../types';
+
+// ==========================================================================
+// Types
+// ==========================================================================
+
+export interface ExportProgress {
+  stage: 'preparing' | 'generating' | 'rendering' | 'encoding' | 'finalizing';
+  percent: number;
+  message?: string;
+}
+
+export type ExportFormat = 'json' | 'midi' | 'pdf' | 'png' | 'svg' | 'wav' | 'mp3';
+
+export interface JSONExportOptions {
+  includeMetadata?: boolean;
+  prettyPrint?: boolean;
+}
+
+export interface ImageExportOptions {
+  /** Width in pixels (default: 800) */
+  width?: number;
+  /** Include title header (default: true) */
+  includeHeader?: boolean;
+  /** Include metadata (tempo, time signature) (default: true) */
+  includeMetadata?: boolean;
+  /** Background color (default: white) */
+  backgroundColor?: string;
+}
+
+export interface AudioExportOptions {
+  /** Number of times to loop the groove (default: 1) */
+  loops?: number;
+}
+
+export interface ExportMetadata {
+  version: string;
+  exportedAt: string;
+  appName: string;
+}
+
+// ==========================================================================
+// Lazy-load caches
+// ==========================================================================
+
+let jsPDFModule: typeof import('jspdf') | null = null;
+let QRCodeModule: typeof import('qrcode') | null = null;
+let MidiWriterModule: typeof import('midi-writer-js') | null = null;
+let LamejsModule: typeof import('@breezystack/lamejs') | null = null;
+
+export async function getJsPDF() {
+  if (!jsPDFModule) {
+    jsPDFModule = await import('jspdf');
+  }
+  return jsPDFModule.jsPDF;
+}
+
+export async function getQRCode() {
+  if (!QRCodeModule) {
+    QRCodeModule = await import('qrcode');
+  }
+  return QRCodeModule;
+}
+
+export async function getMidiWriter() {
+  if (!MidiWriterModule) {
+    MidiWriterModule = await import('midi-writer-js');
+  }
+  return MidiWriterModule.default;
+}
+
+export async function getMp3Encoder() {
+  if (!LamejsModule) {
+    LamejsModule = await import('@breezystack/lamejs');
+  }
+  return LamejsModule.Mp3Encoder;
+}
+
+// ==========================================================================
+// Utilities
+// ==========================================================================
+
+/**
+ * Yield to the main thread to keep UI responsive during heavy exports.
+ * Uses requestIdleCallback when available, falls back to setTimeout.
+ */
+export function yieldToMain(): Promise<void> {
+  return new Promise((resolve) => {
+    if ('requestIdleCallback' in window) {
+      requestIdleCallback(() => resolve(), { timeout: 50 });
+    } else {
+      setTimeout(resolve, 0);
+    }
+  });
+}
+
+/**
+ * Sanitize SVG content using DOMPurify to remove potentially dangerous elements.
+ */
+export function sanitizeSVG(svgContent: string): string {
+  return DOMPurify.sanitize(svgContent, {
+    USE_PROFILES: { svg: true, svgFilters: true },
+    ADD_TAGS: ['use'],
+    ADD_ATTR: ['xlink:href'],
+  });
+}
+
+/**
+ * Escape XML special characters for safe embedding in SVG/XML output.
+ *
+ * Security notes:
+ * - Converts raw text to XML-safe text entities
+ * - Does NOT remove all special characters, only escapes them
+ * - Result is safe to embed in SVG text elements
+ * - NOT suitable for use outside of XML/SVG contexts
+ */
+export function escapeXml(str: string): string {
+  if (!str || typeof str !== 'string') return '';
+
+  return str
+    // Remove null bytes and control characters (except tab, newline, carriage return)
+    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+    // Escape backticks to prevent template literal injection
+    .replace(/`/g, '&#96;');
+}
+
+/**
+ * Generate a sanitized filename for the given groove and format.
+ */
+export function generateFilename(groove: GrooveData, format: ExportFormat): string {
+  const baseName = groove.title?.trim() || 'groove';
+  const sanitized = baseName.replace(/[^a-zA-Z0-9-_\s]/g, '').replace(/\s+/g, '-');
+  return `${sanitized}.${format}`;
+}
+
+/**
+ * Trigger a file download in the browser.
+ */
+export function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Check if a format is currently supported.
+ */
+export function isFormatSupported(format: ExportFormat): boolean {
+  const supportedFormats: ExportFormat[] = ['json', 'pdf', 'png', 'svg', 'midi', 'mp3'];
+  return supportedFormats.includes(format);
+}
+
+/**
+ * Get display information for an export format.
+ */
+export function getFormatInfo(format: ExportFormat): {
+  label: string;
+  description: string;
+  extension: string;
+  supported: boolean;
+} {
+  const formats: Record<ExportFormat, { label: string; description: string; extension: string }> = {
+    json: { label: 'JSON', description: 'Groovy project file - can be imported back into Groovy', extension: '.json' },
+    midi: { label: 'MIDI', description: 'Standard MIDI file - import into DAWs like Ableton, Logic, FL Studio', extension: '.mid' },
+    pdf: { label: 'PDF', description: 'Print-ready sheet music document', extension: '.pdf' },
+    png: { label: 'PNG Image', description: 'High-quality image of the drum grid', extension: '.png' },
+    svg: { label: 'SVG Image', description: 'Scalable vector image of the drum grid', extension: '.svg' },
+    wav: { label: 'WAV Audio', description: 'Uncompressed audio file of the pattern', extension: '.wav' },
+    mp3: { label: 'MP3 Audio', description: 'Compressed audio file of the pattern', extension: '.mp3' },
+  };
+
+  return { ...formats[format], supported: isFormatSupported(format) };
+}
+
+/** All available export formats */
+export const ALL_EXPORT_FORMATS: ExportFormat[] = ['json', 'midi', 'pdf', 'png', 'svg', 'wav', 'mp3'];

--- a/src/core/exporters/index.ts
+++ b/src/core/exporters/index.ts
@@ -1,7 +1,3 @@
-/**
- * Re-export shim — all export logic lives in src/core/exporters/.
- * This file preserves the original import path for existing callers.
- */
 export type {
   ExportProgress,
   ExportFormat,
@@ -9,7 +5,7 @@ export type {
   ImageExportOptions,
   AudioExportOptions,
   ExportMetadata,
-} from './exporters';
+} from './helpers';
 export {
   yieldToMain,
   sanitizeSVG,
@@ -19,8 +15,11 @@ export {
   isFormatSupported,
   getFormatInfo,
   ALL_EXPORT_FORMATS,
-  exportToJSON,
-  downloadAsJSON,
+} from './helpers';
+
+export { exportToJSON, downloadAsJSON } from './exportJSON';
+
+export {
   generateSheetMusicSVG,
   exportToSVG,
   downloadAsSVG,
@@ -28,9 +27,6 @@ export {
   downloadAsPNG,
   exportToPDF,
   downloadAsPDF,
-  DRUM_SAMPLE_FILES,
-  exportToMIDI,
-  downloadAsMIDI,
-  exportToMP3,
-  downloadAsMP3,
-} from './exporters';
+} from './exportImage';
+
+export { DRUM_SAMPLE_FILES, exportToMIDI, downloadAsMIDI, exportToMP3, downloadAsMP3 } from './exportAudio';

--- a/src/core/stickingCodec.ts
+++ b/src/core/stickingCodec.ts
@@ -1,0 +1,91 @@
+/**
+ * Sticking codec — encodes/decodes per-measure sticking arrays to/from URL-safe strings.
+ * Extracted from GrooveURLCodec.ts to isolate sticking-specific logic.
+ */
+
+import { GrooveData, DrumVoice, StickingValue } from '../types';
+import { MEASURE_SEP } from './urlCodecSchemas';
+
+/**
+ * Sticking encoding: maps StickingValue to a single URL-safe character.
+ * null → '-', 'R' → 'r', 'L' → 'l', 'L/R' → 'b' (both)
+ */
+const STICKING_ENCODE: Record<string, string> = {
+  'R': 'r',
+  'L': 'l',
+  'L/R': 'b',
+};
+const STICKING_DECODE: Record<string, StickingValue> = {
+  'r': 'R',
+  'l': 'L',
+  'b': 'L/R',
+};
+/** Valid decoded sticking characters (excluding rest '-') */
+const VALID_STICKING_CHARS = new Set(['r', 'l', 'b', '-']);
+
+/**
+ * Encode sticking arrays from all measures into a single URL-safe string.
+ * Format: |<measure1chars>|<measure2chars>|...
+ * Characters: 'r'=R, 'l'=L, 'b'=L/R, '-'=null
+ * Returns null if all sticking values are null (nothing to encode).
+ */
+export function encodeStickingPattern(groove: GrooveData): string | null {
+  const hasAnySticking = groove.measures.some(m =>
+    m.sticking && m.sticking.some(v => v !== null)
+  );
+  if (!hasAnySticking) return null;
+
+  const parts: string[] = [];
+  for (const measure of groove.measures) {
+    const sticking = measure.sticking;
+    if (!sticking || sticking.length === 0) {
+      const firstVoice = Object.keys(measure.notes)[0] as DrumVoice | undefined;
+      const length = firstVoice ? (measure.notes[firstVoice]?.length ?? 0) : 0;
+      parts.push('-'.repeat(length));
+    } else {
+      parts.push(sticking.map(v => (v !== null ? STICKING_ENCODE[v] : '-')).join(''));
+    }
+  }
+
+  return MEASURE_SEP + parts.join(MEASURE_SEP) + MEASURE_SEP;
+}
+
+/**
+ * Decode sticking URL parameter back to per-measure StickingValue arrays.
+ * Validates each character (T-02-07). Invalid characters are treated as null.
+ * Returns an array of sticking arrays (one per measure), or null if no sticking param.
+ */
+export function decodeStickingPattern(
+  param: string,
+  numMeasures: number,
+  notesPerMeasure: number
+): (StickingValue[] | undefined)[] {
+  // Trim exactly one leading/trailing MEASURE_SEP so that empty middle measures
+  // keep their positional index and don't get shifted (C8).
+  const trimmed = param.startsWith(MEASURE_SEP) ? param.slice(1) : param;
+  const trimmed2 = trimmed.endsWith(MEASURE_SEP) ? trimmed.slice(0, -1) : trimmed;
+  const measurePatterns = trimmed2.split(MEASURE_SEP); // no .filter — preserve empty slots
+  const result: (StickingValue[] | undefined)[] = [];
+
+  for (let m = 0; m < numMeasures; m++) {
+    const chars = measurePatterns[m] ?? '';
+    if (chars.length === 0) {
+      result.push(undefined);
+      continue;
+    }
+    const sticking: StickingValue[] = [];
+    for (let i = 0; i < notesPerMeasure; i++) {
+      const ch = i < chars.length ? chars[i] : '-';
+      if (!VALID_STICKING_CHARS.has(ch)) {
+        // T-02-07: reject invalid sticking characters — treat as null
+        sticking.push(null);
+      } else {
+        sticking.push(STICKING_DECODE[ch] ?? null);
+      }
+    }
+    const hasValues = sticking.some(v => v !== null);
+    result.push(hasValues ? sticking : undefined);
+  }
+
+  return result;
+}

--- a/src/core/stickingUtils.ts
+++ b/src/core/stickingUtils.ts
@@ -1,0 +1,76 @@
+import { GrooveData, DrumVoice, ALL_DRUM_VOICES } from '../types';
+import { GrooveUtils } from './GrooveUtils';
+
+function areNotesIdentical(
+  notes1: Record<DrumVoice, boolean[]>,
+  notes2: Record<DrumVoice, boolean[]>
+): boolean {
+  return ALL_DRUM_VOICES.every(voice => {
+    const arr1 = notes1[voice];
+    const arr2 = notes2[voice];
+    if (!arr1 || !arr2) return arr1 === arr2;
+    if (arr1.length !== arr2.length) return false;
+    return arr1.every((v, i) => v === arr2[i]);
+  });
+}
+
+/**
+ * Find measures with the same note pattern as the target measure.
+ * Similarity criteria (per D-05):
+ * - Same time signature (beats x noteValue)
+ * - Same subdivision count (notesPerMeasure)
+ * - Identical note patterns across all voices (including articulation)
+ *
+ * Returns indices of similar measures, excluding the target measure itself.
+ */
+export function findSimilarMeasures(groove: GrooveData, targetMeasureIndex: number): number[] {
+  const target = groove.measures[targetMeasureIndex];
+  if (!target) return [];
+
+  const targetTs = target.timeSignature || groove.timeSignature;
+  const targetNotesPerMeasure = GrooveUtils.calcNotesPerMeasure(
+    groove.division,
+    targetTs.beats,
+    targetTs.noteValue
+  );
+
+  const similar: number[] = [];
+  for (let i = 0; i < groove.measures.length; i++) {
+    if (i === targetMeasureIndex) continue;
+    const candidate = groove.measures[i];
+    const candidateTs = candidate.timeSignature || groove.timeSignature;
+
+    if (
+      candidateTs.beats !== targetTs.beats ||
+      candidateTs.noteValue !== targetTs.noteValue
+    ) {
+      continue;
+    }
+
+    const candidateNotesPerMeasure = GrooveUtils.calcNotesPerMeasure(
+      groove.division,
+      candidateTs.beats,
+      candidateTs.noteValue
+    );
+    if (candidateNotesPerMeasure !== targetNotesPerMeasure) continue;
+
+    if (areNotesIdentical(target.notes, candidate.notes)) {
+      similar.push(i);
+    }
+  }
+
+  return similar;
+}
+
+/**
+ * Apply the sticking from a source measure to all similar measures.
+ * Returns the set of measure indices that were updated (for feedback messages).
+ * Returns empty array if source has no sticking or no similar measures found.
+ * The sticking array is deep-copied to each target measure (T-02-09).
+ */
+export function applyStickingToSimilar(groove: GrooveData, sourceMeasureIndex: number): number[] {
+  const sourceSticking = groove.measures[sourceMeasureIndex]?.sticking;
+  if (!sourceSticking || !sourceSticking.some(v => v !== null)) return [];
+
+  return findSimilarMeasures(groove, sourceMeasureIndex);
+}

--- a/src/core/urlCodecSchemas.ts
+++ b/src/core/urlCodecSchemas.ts
@@ -1,0 +1,103 @@
+/**
+ * Zod validation schemas and shared constants for GrooveURLCodec.
+ * Extracted to keep GrooveURLCodec.ts focused on encode/decode logic.
+ */
+
+import { z } from 'zod';
+import { Division } from '../types';
+
+export const VALIDATION = {
+  TEMPO: { MIN: 20, MAX: 400, DEFAULT: 120 },
+  SWING: { MIN: 0, MAX: 100, DEFAULT: 0 },
+  MEASURES: { MIN: 1, MAX: 32, DEFAULT: 1 },
+  BEATS: { MIN: 1, MAX: 16, DEFAULT: 4 },
+  TITLE_MAX_LENGTH: 200,
+  AUTHOR_MAX_LENGTH: 100,
+  COMMENTS_MAX_LENGTH: 1000,
+  PATTERN_MAX_LENGTH: 2000,
+  STICKING_MAX_LENGTH: 600,
+} as const;
+
+/** Valid divisions - matches Division type in types.ts */
+export const VALID_DIVISIONS = [4, 8, 12, 16, 24, 32, 48] as const;
+export const VALID_NOTE_VALUES = [4, 8, 16] as const;
+
+/** Rest character in URL patterns */
+export const REST_CHAR = '-';
+
+/** Measure separator in URL patterns */
+export const MEASURE_SEP = '|';
+
+export const timeSignatureSchema = z.string()
+  .regex(/^\d{1,2}\/\d{1,2}$/, 'Invalid time signature format')
+  .transform((str): { beats: number; noteValue: number } => {
+    const [beats, noteValue] = str.split('/').map(Number);
+    return { beats, noteValue };
+  })
+  .refine(
+    (ts) => ts.beats >= VALIDATION.BEATS.MIN && ts.beats <= VALIDATION.BEATS.MAX,
+    { message: `Beats must be between ${VALIDATION.BEATS.MIN} and ${VALIDATION.BEATS.MAX}` }
+  )
+  .refine(
+    (ts) => VALID_NOTE_VALUES.includes(ts.noteValue as 4 | 8 | 16),
+    { message: `Note value must be one of: ${VALID_NOTE_VALUES.join(', ')}` }
+  );
+
+export const divisionSchema = z.coerce.number()
+  .refine(
+    (n) => VALID_DIVISIONS.includes(n as Division),
+    { message: `Division must be one of: ${VALID_DIVISIONS.join(', ')}` }
+  )
+  .transform((n) => n as Division);
+
+export const tempoSchema = z.coerce.number()
+  .min(VALIDATION.TEMPO.MIN, `Tempo must be at least ${VALIDATION.TEMPO.MIN}`)
+  .max(VALIDATION.TEMPO.MAX, `Tempo must be at most ${VALIDATION.TEMPO.MAX}`)
+  .default(VALIDATION.TEMPO.DEFAULT);
+
+export const swingSchema = z.coerce.number()
+  .min(VALIDATION.SWING.MIN, `Swing must be at least ${VALIDATION.SWING.MIN}`)
+  .max(VALIDATION.SWING.MAX, `Swing must be at most ${VALIDATION.SWING.MAX}`)
+  .default(VALIDATION.SWING.DEFAULT);
+
+export const measuresSchema = z.coerce.number()
+  .min(VALIDATION.MEASURES.MIN, `Measures must be at least ${VALIDATION.MEASURES.MIN}`)
+  .max(VALIDATION.MEASURES.MAX, `Measures must be at most ${VALIDATION.MEASURES.MAX}`)
+  .default(VALIDATION.MEASURES.DEFAULT);
+
+export const titleSchema = z.string()
+  .max(VALIDATION.TITLE_MAX_LENGTH, `Title must be at most ${VALIDATION.TITLE_MAX_LENGTH} characters`)
+  .optional();
+
+export const authorSchema = z.string()
+  .max(VALIDATION.AUTHOR_MAX_LENGTH, `Author must be at most ${VALIDATION.AUTHOR_MAX_LENGTH} characters`)
+  .optional();
+
+export const commentsSchema = z.string()
+  .max(VALIDATION.COMMENTS_MAX_LENGTH, `Comments must be at most ${VALIDATION.COMMENTS_MAX_LENGTH} characters`)
+  .optional();
+
+export const patternSchema = z.string()
+  .max(VALIDATION.PATTERN_MAX_LENGTH, `Pattern too long`)
+  .regex(/^[|a-zA-Z0-9\-+^]*$/, 'Invalid characters in pattern')
+  .optional();
+
+export const stickingParamSchema = z.string()
+  .max(VALIDATION.STICKING_MAX_LENGTH, 'Sticking parameter too long')
+  .regex(/^[rlb|-]*$/, 'Invalid characters in sticking parameter')
+  .optional();
+
+/**
+ * Safe parse helper - returns default value on validation failure
+ */
+export function safeParse<T>(
+  schema: z.ZodType<T>,
+  value: string | null | undefined,
+  defaultValue: T
+): T {
+  if (value === null || value === undefined) {
+    return defaultValue;
+  }
+  const result = schema.safeParse(value);
+  return result.success ? result.data : defaultValue;
+}

--- a/src/hooks/useDrumGrid.ts
+++ b/src/hooks/useDrumGrid.ts
@@ -2,13 +2,15 @@
  * useDrumGrid Hook
  *
  * Shared logic for DrumGrid and DrumGridDark components.
- * Handles voice selection, drag painting, touch support, context menus, and bulk operations.
+ * Coordinates voice selection state, drag painting, and context menu sub-hooks.
  */
 
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { GrooveData, DrumVoice } from '../types';
 import { GrooveUtils, HI_HAT_PATTERNS, SNARE_PATTERNS, KICK_PATTERNS, BulkPattern } from '../core';
 import { DRUM_ROWS, DrumRow } from '../core/DrumVoiceConfig';
+import { useGridDragPaint } from './useGridDragPaint';
+import { useGridContextMenu } from './useGridContextMenu';
 
 /** A single note change for batch operations */
 export interface NoteChange {
@@ -88,14 +90,13 @@ export function useDrumGrid({
   onPreview,
   advancedEditMode = false,
 }: UseDrumGridProps): UseDrumGridReturn {
-  // Calculate notes per measure for the global time signature
   const notesPerMeasure = GrooveUtils.calcNotesPerMeasure(
     groove.division,
     groove.timeSignature.beats,
     groove.timeSignature.noteValue
   );
 
-  // Voice selection state - tracks which voices are selected for each row at each position
+  // Voice selection state — shared between drag and context menu sub-hooks
   const [voiceSelections, setVoiceSelections] = useState<Record<string, DrumVoice[]>>(() => {
     const initial: Record<string, DrumVoice[]> = {};
     groove.measures.forEach((_, measureIndex) => {
@@ -108,54 +109,7 @@ export function useDrumGrid({
     return initial;
   });
 
-  // Context menu state
-  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
-  const contextMenuRef = useRef<HTMLDivElement>(null);
-
-  // Drag state
-  const [isDragging, setIsDragging] = useState(false);
-  const [dragMode, setDragMode] = useState<'paint' | 'erase' | null>(null);
-  const [dragMeasureIndex, setDragMeasureIndex] = useState<number>(0);
-  const [dragSourceVoices, setDragSourceVoices] = useState<DrumVoice[] | null>(null);
-
-  // Touch state
-  const [touchStartTime, setTouchStartTime] = useState<number>(0);
-  const [touchMoved, setTouchMoved] = useState(false);
-
-  // Bulk operations dialog state
-  const [bulkDialog, setBulkDialog] = useState<BulkDialogState | null>(null);
-
-  const getContextMenuPosition = useCallback((
-    eventTarget: EventTarget,
-    rowIndex: number
-  ): Pick<ContextMenuState, 'x' | 'y' | 'placement'> => {
-    const target = eventTarget as HTMLElement;
-    const rect = target.getBoundingClientRect();
-    const menuWidth = 200;
-    const menuHeight = 34 + DRUM_ROWS[rowIndex].variations.length * 38 + 8;
-    const gap = 6;
-    const viewportPadding = 8;
-    const roomBelow = window.innerHeight - rect.bottom - gap - viewportPadding;
-    const roomAbove = rect.top - gap - viewportPadding;
-    const hasRoomBelow = roomBelow >= menuHeight;
-    const hasRoomAbove = roomAbove >= menuHeight;
-    const placement = hasRoomBelow || (!hasRoomAbove && roomBelow >= roomAbove) ? 'below' : 'above';
-
-    return {
-      x: Math.min(
-        Math.max(rect.left, viewportPadding),
-        window.innerWidth - menuWidth - viewportPadding
-      ),
-      y: placement === 'below'
-        ? rect.bottom + gap
-        : rect.top - menuHeight - gap,
-      placement,
-    };
-  }, []);
-
-  // ==========================================================================
-  // Helper functions
-  // ==========================================================================
+  // ===== Helper functions =====
 
   const isDownbeat = useCallback((pos: number) => {
     const notesPerBeat = groove.division / groove.timeSignature.beats;
@@ -213,375 +167,48 @@ export function useDrumGrid({
     return [];
   }, []);
 
-  // ==========================================================================
-  // Drag operations
-  // ==========================================================================
+  // ===== Sub-hooks =====
 
-  const applyDragAction = useCallback((
-    mode: 'paint' | 'erase',
-    measureIndex: number,
-    rowIndex: number,
-    position: number,
-    sourceVoices?: DrumVoice[]
-  ) => {
-    const measure = groove.measures[measureIndex];
-    if (!measure) return;
+  const ctx = useGridContextMenu({
+    groove,
+    onNoteToggle,
+    onSetNotes,
+    onPreview,
+    advancedEditMode,
+    getVoicesForPosition,
+    isPositionActive,
+    setVoiceSelections,
+  });
 
-    const isActive = isPositionActive(measureIndex, rowIndex, position);
+  const drag = useGridDragPaint({
+    groove,
+    onNoteToggle,
+    getVoicesForPosition,
+    isPositionActive,
+    setVoiceSelections,
+    setContextMenu: ctx.setContextMenu,
+    getContextMenuPosition: ctx.getContextMenuPosition,
+  });
 
-    if (mode === 'paint' && !isActive) {
-      const voices = sourceVoices || getVoicesForPosition(measureIndex, rowIndex, position);
-      voices.forEach(voice => {
-        onNoteToggle(voice, position, measureIndex);
-      });
-      if (sourceVoices) {
-        const key = `${measureIndex}-${rowIndex}-${position}`;
-        setVoiceSelections(prev => ({ ...prev, [key]: sourceVoices }));
-      }
-    } else if (mode === 'erase' && isActive) {
-      const row = DRUM_ROWS[rowIndex];
-      row.variations.forEach(v => {
-        v.voices.forEach(voice => {
-          if (measure.notes[voice]?.[position]) {
-            onNoteToggle(voice, position, measureIndex);
-          }
-        });
-      });
-    }
-  }, [groove.measures, isPositionActive, getVoicesForPosition, onNoteToggle]);
-
-  // ==========================================================================
-  // Event handlers
-  // ==========================================================================
-
-  const handleMouseDown = useCallback((
-    event: React.MouseEvent,
-    measureIndex: number,
-    rowIndex: number,
-    position: number
-  ) => {
-    if (event.ctrlKey || event.metaKey) {
-      event.preventDefault();
-      const sourceVoices = getVoicesForPosition(measureIndex, rowIndex, position);
-      setIsDragging(true);
-      setDragMode('paint');
-      setDragMeasureIndex(measureIndex);
-      setDragSourceVoices(sourceVoices);
-      applyDragAction('paint', measureIndex, rowIndex, position, sourceVoices);
-    } else if (event.altKey || event.shiftKey) {
-      event.preventDefault();
-      setIsDragging(true);
-      setDragMode('erase');
-      setDragMeasureIndex(measureIndex);
-      setDragSourceVoices(null);
-      applyDragAction('erase', measureIndex, rowIndex, position);
-    }
-  }, [getVoicesForPosition, applyDragAction]);
-
-  const handleMouseEnter = useCallback((
-    measureIndex: number,
-    rowIndex: number,
-    position: number
-  ) => {
-    if (isDragging && dragMode && measureIndex === dragMeasureIndex) {
-      applyDragAction(dragMode, measureIndex, rowIndex, position, dragSourceVoices || undefined);
-    }
-  }, [isDragging, dragMode, dragMeasureIndex, dragSourceVoices, applyDragAction]);
-
-  const handleTouchStart = useCallback((
-    _event: React.TouchEvent,
-    measureIndex: number,
-    rowIndex: number,
-    position: number
-  ) => {
-    setTouchStartTime(Date.now());
-    setTouchMoved(false);
-    const sourceVoices = getVoicesForPosition(measureIndex, rowIndex, position);
-    setIsDragging(true);
-    setDragMode('paint');
-    setDragMeasureIndex(measureIndex);
-    setDragSourceVoices(sourceVoices);
-    applyDragAction('paint', measureIndex, rowIndex, position, sourceVoices);
-  }, [getVoicesForPosition, applyDragAction]);
-
-  const handleTouchMove = useCallback((event: React.TouchEvent) => {
-    setTouchMoved(true);
-    if (!isDragging) return;
-
-    const touch = event.touches[0];
-    const element = document.elementFromPoint(touch.clientX, touch.clientY);
-
-    // Check for both class names used by the two grid components
-    if (element && (element.classList.contains('note-cell') || element.classList.contains('drum-cell'))) {
-      const cellButton = element as HTMLButtonElement;
-      const mIdx = parseInt(cellButton.dataset.measureIndex || '-1');
-      const rIdx = parseInt(cellButton.dataset.rowIndex || '-1');
-      const pos = parseInt(cellButton.dataset.position || '-1');
-
-      if (mIdx >= 0 && rIdx >= 0 && pos >= 0 && dragMode && mIdx === dragMeasureIndex) {
-        applyDragAction(dragMode, mIdx, rIdx, pos, dragSourceVoices || undefined);
-      }
-    }
-  }, [isDragging, dragMode, dragMeasureIndex, dragSourceVoices, applyDragAction]);
-
-  const handleTouchEnd = useCallback((
-    event: React.TouchEvent,
-    measureIndex: number,
-    rowIndex: number,
-    position: number
-  ) => {
-    const touchDuration = Date.now() - touchStartTime;
-
-    if (touchDuration > 500 && !touchMoved) {
-      event.preventDefault();
-      const row = DRUM_ROWS[rowIndex];
-      if (row.variations.length > 1) {
-        // Get touch position for context menu
-        const menuPosition = getContextMenuPosition(event.currentTarget, rowIndex);
-        setContextMenu({
-          visible: true,
-          ...menuPosition,
-          rowIndex,
-          position,
-          measureIndex,
-        });
-      }
-    }
-
-    setIsDragging(false);
-    setDragMode(null);
-    setDragSourceVoices(null);
-    setTouchMoved(false);
-  }, [touchStartTime, touchMoved, getContextMenuPosition]);
-
+  // Guard left-click against ongoing drag (ctx.handleLeftClick doesn't own isDragging state)
   const handleLeftClick = useCallback((
     event: React.MouseEvent,
     measureIndex: number,
     rowIndex: number,
     position: number
   ) => {
-    if (isDragging) return;
-
-    const measure = groove.measures[measureIndex];
-    if (!measure) return;
-
-    if (advancedEditMode) {
-      // In advanced mode, left-click shows context menu
-      event.preventDefault();
-      const row = DRUM_ROWS[rowIndex];
-      if (row.variations.length > 1) {
-        const menuPosition = getContextMenuPosition(event.currentTarget, rowIndex);
-        setContextMenu({
-          visible: true,
-          ...menuPosition,
-          rowIndex,
-          position,
-          measureIndex,
-        });
-      }
-      return;
-    }
-
-    const voices = getVoicesForPosition(measureIndex, rowIndex, position);
-    const isActive = isPositionActive(measureIndex, rowIndex, position);
-
-    if (isActive) {
-      // Turn off all voices for this row at this position
-      const row = DRUM_ROWS[rowIndex];
-      row.variations.forEach(v => {
-        v.voices.forEach(voice => {
-          if (measure.notes[voice]?.[position]) {
-            onNoteToggle(voice, position, measureIndex);
-          }
-        });
-      });
-    } else {
-      // First, clear any existing notes for this row at this position
-      const row = DRUM_ROWS[rowIndex];
-      row.variations.forEach(v => {
-        v.voices.forEach(voice => {
-          if (measure.notes[voice]?.[position]) {
-            onNoteToggle(voice, position, measureIndex);
-          }
-        });
-      });
-      // Then turn on selected voices
-      voices.forEach(voice => {
-        onNoteToggle(voice, position, measureIndex);
-      });
-      onPreview(voices[0]);
-    }
-  }, [isDragging, groove.measures, advancedEditMode, getContextMenuPosition, getVoicesForPosition, isPositionActive, onNoteToggle, onPreview]);
-
-  const handleRightClick = useCallback((
-    event: React.MouseEvent,
-    measureIndex: number,
-    rowIndex: number,
-    position: number
-  ) => {
-    event.preventDefault();
-    const row = DRUM_ROWS[rowIndex];
-    if (row.variations.length > 1) {
-      const menuPosition = getContextMenuPosition(event.currentTarget, rowIndex);
-      setContextMenu({
-        visible: true,
-        ...menuPosition,
-        rowIndex,
-        position,
-        measureIndex,
-      });
-    }
-  }, [getContextMenuPosition]);
-
-  const handleVoiceSelect = useCallback((voices: DrumVoice[]) => {
-    if (!contextMenu) return;
-
-    const { measureIndex, rowIndex, position } = contextMenu;
-    const measure = groove.measures[measureIndex];
-    if (!measure) return;
-
-    const key = `${measureIndex}-${rowIndex}-${position}`;
-    setVoiceSelections(prev => ({ ...prev, [key]: voices }));
-
-    if (onSetNotes) {
-      const changes: NoteChange[] = [];
-      const row = DRUM_ROWS[rowIndex];
-
-      // Clear any existing notes for this row at this position
-      row.variations.forEach(v => {
-        v.voices.forEach(voice => {
-          if (measure.notes[voice]?.[position]) {
-            changes.push({ voice, position, measureIndex, value: false });
-          }
-        });
-      });
-
-      // Set the new voices
-      voices.forEach(voice => {
-        changes.push({ voice, position, measureIndex, value: true });
-      });
-
-      onSetNotes(changes);
-    } else {
-      // Fallback to individual toggles
-      const row = DRUM_ROWS[rowIndex];
-      row.variations.forEach(v => {
-        v.voices.forEach(voice => {
-          if (measure.notes[voice]?.[position]) {
-            onNoteToggle(voice, position, measureIndex);
-          }
-        });
-      });
-      voices.forEach(voice => {
-        onNoteToggle(voice, position, measureIndex);
-      });
-    }
-
-    onPreview(voices[0]);
-    setContextMenu(null);
-  }, [contextMenu, groove.measures, onSetNotes, onNoteToggle, onPreview]);
-
-  const handleVoiceLabelClick = useCallback((rowIndex: number, measureIndex: number) => {
-    setBulkDialog({ visible: true, rowIndex, measureIndex });
-  }, []);
-
-  const handleBulkPatternSelect = useCallback((pattern: BulkPattern) => {
-    if (!bulkDialog) return;
-
-    const { rowIndex, measureIndex } = bulkDialog;
-    const measure = groove.measures[measureIndex];
-    if (!measure) return;
-
-    const row = DRUM_ROWS[rowIndex];
-
-    // First, clear all voices for this row in this measure
-    for (let pos = 0; pos < notesPerMeasure; pos++) {
-      row.variations.forEach(v => {
-        v.voices.forEach(voice => {
-          if (measure.notes[voice]?.[pos]) {
-            onNoteToggle(voice, pos, measureIndex);
-          }
-        });
-      });
-    }
-
-    // Then, apply the pattern
-    for (let pos = 0; pos < notesPerMeasure; pos++) {
-      const shouldBeOn = pattern.pattern(pos, notesPerMeasure);
-      if (shouldBeOn && pattern.voices.length > 0) {
-        pattern.voices.forEach(voice => {
-          onNoteToggle(voice, pos, measureIndex);
-        });
-      }
-    }
-
-    if (pattern.voices.length > 0) {
-      onPreview(pattern.voices[0]);
-    }
-  }, [bulkDialog, groove.measures, notesPerMeasure, onNoteToggle, onPreview]);
-
-  // ==========================================================================
-  // Effects
-  // ==========================================================================
-
-  // Close context menu when clicking outside or handle keyboard shortcuts
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (contextMenuRef.current && !contextMenuRef.current.contains(event.target as Node)) {
-        setContextMenu(null);
-      }
-    };
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (!contextMenu?.visible) return;
-
-      const row = DRUM_ROWS[contextMenu.rowIndex];
-      const variation = row.variations.find(v => v.shortcut === event.key);
-
-      if (variation) {
-        event.preventDefault();
-        handleVoiceSelect(variation.voices);
-      } else if (event.key === 'Escape') {
-        setContextMenu(null);
-      }
-    };
-
-    if (contextMenu?.visible) {
-      document.addEventListener('mousedown', handleClickOutside);
-      document.addEventListener('keydown', handleKeyDown);
-      return () => {
-        document.removeEventListener('mousedown', handleClickOutside);
-        document.removeEventListener('keydown', handleKeyDown);
-      };
-    }
-  }, [contextMenu, handleVoiceSelect]);
-
-  // Handle global mouseup to end drag operations
-  useEffect(() => {
-    const handleMouseUp = () => {
-      if (isDragging) {
-        setIsDragging(false);
-        setDragMode(null);
-        setDragSourceVoices(null);
-      }
-    };
-
-    document.addEventListener('mouseup', handleMouseUp);
-    return () => {
-      document.removeEventListener('mouseup', handleMouseUp);
-    };
-  }, [isDragging]);
+    if (drag.isDragging) return;
+    ctx.handleLeftClick(event, measureIndex, rowIndex, position);
+  }, [drag.isDragging, ctx.handleLeftClick]);
 
   return {
-    // State
     voiceSelections,
-    contextMenu,
-    isDragging,
-    dragMode,
-    bulkDialog,
-    contextMenuRef: contextMenuRef as React.RefObject<HTMLDivElement>,
+    contextMenu: ctx.contextMenu,
+    isDragging: drag.isDragging,
+    dragMode: drag.dragMode,
+    bulkDialog: ctx.bulkDialog,
+    contextMenuRef: ctx.contextMenuRef,
 
-    // Helper functions
     isDownbeat,
     getVoicesForPosition,
     isPositionActive,
@@ -590,21 +217,19 @@ export function useDrumGrid({
     getPositionsForMeasure,
     getBulkPatternsForRow,
 
-    // Event handlers
-    handleMouseDown,
-    handleMouseEnter,
-    handleTouchStart,
-    handleTouchMove,
-    handleTouchEnd,
+    handleMouseDown: drag.handleMouseDown,
+    handleMouseEnter: drag.handleMouseEnter,
+    handleTouchStart: drag.handleTouchStart,
+    handleTouchMove: drag.handleTouchMove,
+    handleTouchEnd: drag.handleTouchEnd,
     handleLeftClick,
-    handleRightClick,
-    handleVoiceSelect,
-    handleVoiceLabelClick,
-    handleBulkPatternSelect,
+    handleRightClick: ctx.handleRightClick,
+    handleVoiceSelect: ctx.handleVoiceSelect,
+    handleVoiceLabelClick: ctx.handleVoiceLabelClick,
+    handleBulkPatternSelect: ctx.handleBulkPatternSelect,
 
-    // State setters
-    setContextMenu,
-    setBulkDialog,
+    setContextMenu: ctx.setContextMenu,
+    setBulkDialog: ctx.setBulkDialog,
   };
 }
 

--- a/src/hooks/useGridContextMenu.ts
+++ b/src/hooks/useGridContextMenu.ts
@@ -1,0 +1,274 @@
+/**
+ * useGridContextMenu - context menu, bulk dialog, and click handling for drum grids.
+ * Extracted from useDrumGrid.ts.
+ */
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { GrooveData, DrumVoice } from '../types';
+import { GrooveUtils, BulkPattern } from '../core';
+import { DRUM_ROWS } from '../core/DrumVoiceConfig';
+import { ContextMenuState, BulkDialogState, NoteChange } from './useDrumGrid';
+
+interface UseGridContextMenuProps {
+  groove: GrooveData;
+  onNoteToggle: (voice: DrumVoice, position: number, measureIndex: number) => void;
+  onSetNotes?: (changes: NoteChange[]) => void;
+  onPreview: (voice: DrumVoice) => void;
+  advancedEditMode: boolean;
+  getVoicesForPosition: (measureIndex: number, rowIndex: number, position: number) => DrumVoice[];
+  isPositionActive: (measureIndex: number, rowIndex: number, position: number) => boolean;
+  setVoiceSelections: React.Dispatch<React.SetStateAction<Record<string, DrumVoice[]>>>;
+}
+
+interface UseGridContextMenuReturn {
+  contextMenu: ContextMenuState | null;
+  setContextMenu: React.Dispatch<React.SetStateAction<ContextMenuState | null>>;
+  contextMenuRef: React.RefObject<HTMLDivElement>;
+  bulkDialog: BulkDialogState | null;
+  setBulkDialog: React.Dispatch<React.SetStateAction<BulkDialogState | null>>;
+  getContextMenuPosition: (eventTarget: EventTarget, rowIndex: number) => Pick<ContextMenuState, 'x' | 'y' | 'placement'>;
+  handleLeftClick: (event: React.MouseEvent, measureIndex: number, rowIndex: number, position: number) => void;
+  handleRightClick: (event: React.MouseEvent, measureIndex: number, rowIndex: number, position: number) => void;
+  handleVoiceSelect: (voices: DrumVoice[]) => void;
+  handleVoiceLabelClick: (rowIndex: number, measureIndex: number) => void;
+  handleBulkPatternSelect: (pattern: BulkPattern) => void;
+}
+
+export function useGridContextMenu({
+  groove,
+  onNoteToggle,
+  onSetNotes,
+  onPreview,
+  advancedEditMode,
+  getVoicesForPosition,
+  isPositionActive,
+  setVoiceSelections,
+}: UseGridContextMenuProps): UseGridContextMenuReturn {
+  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+  const contextMenuRef = useRef<HTMLDivElement>(null);
+  const [bulkDialog, setBulkDialog] = useState<BulkDialogState | null>(null);
+
+  const notesPerMeasure = GrooveUtils.calcNotesPerMeasure(
+    groove.division,
+    groove.timeSignature.beats,
+    groove.timeSignature.noteValue
+  );
+
+  const getContextMenuPosition = useCallback((
+    eventTarget: EventTarget,
+    rowIndex: number
+  ): Pick<ContextMenuState, 'x' | 'y' | 'placement'> => {
+    const target = eventTarget as HTMLElement;
+    const rect = target.getBoundingClientRect();
+    const menuWidth = 200;
+    const menuHeight = 34 + DRUM_ROWS[rowIndex].variations.length * 38 + 8;
+    const gap = 6;
+    const viewportPadding = 8;
+    const roomBelow = window.innerHeight - rect.bottom - gap - viewportPadding;
+    const roomAbove = rect.top - gap - viewportPadding;
+    const hasRoomBelow = roomBelow >= menuHeight;
+    const hasRoomAbove = roomAbove >= menuHeight;
+    const placement = hasRoomBelow || (!hasRoomAbove && roomBelow >= roomAbove) ? 'below' : 'above';
+
+    return {
+      x: Math.min(
+        Math.max(rect.left, viewportPadding),
+        window.innerWidth - menuWidth - viewportPadding
+      ),
+      y: placement === 'below'
+        ? rect.bottom + gap
+        : rect.top - menuHeight - gap,
+      placement,
+    };
+  }, []);
+
+  // Note: isDragging guard is applied by the parent useDrumGrid wrapper
+  const handleLeftClick = useCallback((
+    event: React.MouseEvent,
+    measureIndex: number,
+    rowIndex: number,
+    position: number
+  ) => {
+    const measure = groove.measures[measureIndex];
+    if (!measure) return;
+
+    if (advancedEditMode) {
+      event.preventDefault();
+      const row = DRUM_ROWS[rowIndex];
+      if (row.variations.length > 1) {
+        const menuPosition = getContextMenuPosition(event.currentTarget, rowIndex);
+        setContextMenu({ visible: true, ...menuPosition, rowIndex, position, measureIndex });
+      }
+      return;
+    }
+
+    const voices = getVoicesForPosition(measureIndex, rowIndex, position);
+    const isActive = isPositionActive(measureIndex, rowIndex, position);
+
+    if (isActive) {
+      const row = DRUM_ROWS[rowIndex];
+      row.variations.forEach(v => {
+        v.voices.forEach(voice => {
+          if (measure.notes[voice]?.[position]) {
+            onNoteToggle(voice, position, measureIndex);
+          }
+        });
+      });
+    } else {
+      const row = DRUM_ROWS[rowIndex];
+      row.variations.forEach(v => {
+        v.voices.forEach(voice => {
+          if (measure.notes[voice]?.[position]) {
+            onNoteToggle(voice, position, measureIndex);
+          }
+        });
+      });
+      voices.forEach(voice => {
+        onNoteToggle(voice, position, measureIndex);
+      });
+      onPreview(voices[0]);
+    }
+  }, [groove.measures, advancedEditMode, getContextMenuPosition, getVoicesForPosition, isPositionActive, onNoteToggle, onPreview]);
+
+  const handleRightClick = useCallback((
+    event: React.MouseEvent,
+    measureIndex: number,
+    rowIndex: number,
+    position: number
+  ) => {
+    event.preventDefault();
+    const row = DRUM_ROWS[rowIndex];
+    if (row.variations.length > 1) {
+      const menuPosition = getContextMenuPosition(event.currentTarget, rowIndex);
+      setContextMenu({ visible: true, ...menuPosition, rowIndex, position, measureIndex });
+    }
+  }, [getContextMenuPosition]);
+
+  const handleVoiceSelect = useCallback((voices: DrumVoice[]) => {
+    if (!contextMenu) return;
+
+    const { measureIndex, rowIndex, position } = contextMenu;
+    const measure = groove.measures[measureIndex];
+    if (!measure) return;
+
+    const key = `${measureIndex}-${rowIndex}-${position}`;
+    setVoiceSelections(prev => ({ ...prev, [key]: voices }));
+
+    if (onSetNotes) {
+      const changes: NoteChange[] = [];
+      const row = DRUM_ROWS[rowIndex];
+
+      row.variations.forEach(v => {
+        v.voices.forEach(voice => {
+          if (measure.notes[voice]?.[position]) {
+            changes.push({ voice, position, measureIndex, value: false });
+          }
+        });
+      });
+
+      voices.forEach(voice => {
+        changes.push({ voice, position, measureIndex, value: true });
+      });
+
+      onSetNotes(changes);
+    } else {
+      const row = DRUM_ROWS[rowIndex];
+      row.variations.forEach(v => {
+        v.voices.forEach(voice => {
+          if (measure.notes[voice]?.[position]) {
+            onNoteToggle(voice, position, measureIndex);
+          }
+        });
+      });
+      voices.forEach(voice => {
+        onNoteToggle(voice, position, measureIndex);
+      });
+    }
+
+    onPreview(voices[0]);
+    setContextMenu(null);
+  }, [contextMenu, groove.measures, onSetNotes, onNoteToggle, onPreview, setVoiceSelections]);
+
+  const handleVoiceLabelClick = useCallback((rowIndex: number, measureIndex: number) => {
+    setBulkDialog({ visible: true, rowIndex, measureIndex });
+  }, []);
+
+  const handleBulkPatternSelect = useCallback((pattern: BulkPattern) => {
+    if (!bulkDialog) return;
+
+    const { rowIndex, measureIndex } = bulkDialog;
+    const measure = groove.measures[measureIndex];
+    if (!measure) return;
+
+    const row = DRUM_ROWS[rowIndex];
+
+    for (let pos = 0; pos < notesPerMeasure; pos++) {
+      row.variations.forEach(v => {
+        v.voices.forEach(voice => {
+          if (measure.notes[voice]?.[pos]) {
+            onNoteToggle(voice, pos, measureIndex);
+          }
+        });
+      });
+    }
+
+    for (let pos = 0; pos < notesPerMeasure; pos++) {
+      const shouldBeOn = pattern.pattern(pos, notesPerMeasure);
+      if (shouldBeOn && pattern.voices.length > 0) {
+        pattern.voices.forEach(voice => {
+          onNoteToggle(voice, pos, measureIndex);
+        });
+      }
+    }
+
+    if (pattern.voices.length > 0) {
+      onPreview(pattern.voices[0]);
+    }
+  }, [bulkDialog, groove.measures, notesPerMeasure, onNoteToggle, onPreview]);
+
+  // Close context menu on outside click or Escape/shortcut keys
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (contextMenuRef.current && !contextMenuRef.current.contains(event.target as Node)) {
+        setContextMenu(null);
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!contextMenu?.visible) return;
+
+      const row = DRUM_ROWS[contextMenu.rowIndex];
+      const variation = row.variations.find(v => v.shortcut === event.key);
+
+      if (variation) {
+        event.preventDefault();
+        handleVoiceSelect(variation.voices);
+      } else if (event.key === 'Escape') {
+        setContextMenu(null);
+      }
+    };
+
+    if (contextMenu?.visible) {
+      document.addEventListener('mousedown', handleClickOutside);
+      document.addEventListener('keydown', handleKeyDown);
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+        document.removeEventListener('keydown', handleKeyDown);
+      };
+    }
+  }, [contextMenu, handleVoiceSelect]);
+
+  return {
+    contextMenu,
+    setContextMenu,
+    contextMenuRef: contextMenuRef as React.RefObject<HTMLDivElement>,
+    bulkDialog,
+    setBulkDialog,
+    getContextMenuPosition,
+    handleLeftClick,
+    handleRightClick,
+    handleVoiceSelect,
+    handleVoiceLabelClick,
+    handleBulkPatternSelect,
+  };
+}

--- a/src/hooks/useGridDragPaint.ts
+++ b/src/hooks/useGridDragPaint.ts
@@ -1,0 +1,211 @@
+/**
+ * useGridDragPaint - drag painting, touch, and mouseup-outside handling for drum grids.
+ * Extracted from useDrumGrid.ts.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { GrooveData, DrumVoice } from '../types';
+import { DRUM_ROWS } from '../core/DrumVoiceConfig';
+import { ContextMenuState } from './useDrumGrid';
+
+interface UseGridDragPaintProps {
+  groove: GrooveData;
+  onNoteToggle: (voice: DrumVoice, position: number, measureIndex: number) => void;
+  getVoicesForPosition: (measureIndex: number, rowIndex: number, position: number) => DrumVoice[];
+  isPositionActive: (measureIndex: number, rowIndex: number, position: number) => boolean;
+  setVoiceSelections: React.Dispatch<React.SetStateAction<Record<string, DrumVoice[]>>>;
+  setContextMenu: React.Dispatch<React.SetStateAction<ContextMenuState | null>>;
+  getContextMenuPosition: (eventTarget: EventTarget, rowIndex: number) => Pick<ContextMenuState, 'x' | 'y' | 'placement'>;
+}
+
+interface UseGridDragPaintReturn {
+  isDragging: boolean;
+  dragMode: 'paint' | 'erase' | null;
+  applyDragAction: (
+    mode: 'paint' | 'erase',
+    measureIndex: number,
+    rowIndex: number,
+    position: number,
+    sourceVoices?: DrumVoice[]
+  ) => void;
+  handleMouseDown: (event: React.MouseEvent, measureIndex: number, rowIndex: number, position: number) => void;
+  handleMouseEnter: (measureIndex: number, rowIndex: number, position: number) => void;
+  handleTouchStart: (event: React.TouchEvent, measureIndex: number, rowIndex: number, position: number) => void;
+  handleTouchMove: (event: React.TouchEvent) => void;
+  handleTouchEnd: (event: React.TouchEvent, measureIndex: number, rowIndex: number, position: number) => void;
+}
+
+export function useGridDragPaint({
+  groove,
+  onNoteToggle,
+  getVoicesForPosition,
+  isPositionActive,
+  setVoiceSelections,
+  setContextMenu,
+  getContextMenuPosition,
+}: UseGridDragPaintProps): UseGridDragPaintReturn {
+  const [isDragging, setIsDragging] = useState(false);
+  const [dragMode, setDragMode] = useState<'paint' | 'erase' | null>(null);
+  const [dragMeasureIndex, setDragMeasureIndex] = useState<number>(0);
+  const [dragSourceVoices, setDragSourceVoices] = useState<DrumVoice[] | null>(null);
+  const [touchStartTime, setTouchStartTime] = useState<number>(0);
+  const [touchMoved, setTouchMoved] = useState(false);
+
+  const applyDragAction = useCallback((
+    mode: 'paint' | 'erase',
+    measureIndex: number,
+    rowIndex: number,
+    position: number,
+    sourceVoices?: DrumVoice[]
+  ) => {
+    const measure = groove.measures[measureIndex];
+    if (!measure) return;
+
+    const isActive = isPositionActive(measureIndex, rowIndex, position);
+
+    if (mode === 'paint' && !isActive) {
+      const voices = sourceVoices || getVoicesForPosition(measureIndex, rowIndex, position);
+      voices.forEach(voice => {
+        onNoteToggle(voice, position, measureIndex);
+      });
+      if (sourceVoices) {
+        const key = `${measureIndex}-${rowIndex}-${position}`;
+        setVoiceSelections(prev => ({ ...prev, [key]: sourceVoices }));
+      }
+    } else if (mode === 'erase' && isActive) {
+      const row = DRUM_ROWS[rowIndex];
+      row.variations.forEach(v => {
+        v.voices.forEach(voice => {
+          if (measure.notes[voice]?.[position]) {
+            onNoteToggle(voice, position, measureIndex);
+          }
+        });
+      });
+    }
+  }, [groove.measures, isPositionActive, getVoicesForPosition, onNoteToggle, setVoiceSelections]);
+
+  const handleMouseDown = useCallback((
+    event: React.MouseEvent,
+    measureIndex: number,
+    rowIndex: number,
+    position: number
+  ) => {
+    if (event.ctrlKey || event.metaKey) {
+      event.preventDefault();
+      const sourceVoices = getVoicesForPosition(measureIndex, rowIndex, position);
+      setIsDragging(true);
+      setDragMode('paint');
+      setDragMeasureIndex(measureIndex);
+      setDragSourceVoices(sourceVoices);
+      applyDragAction('paint', measureIndex, rowIndex, position, sourceVoices);
+    } else if (event.altKey || event.shiftKey) {
+      event.preventDefault();
+      setIsDragging(true);
+      setDragMode('erase');
+      setDragMeasureIndex(measureIndex);
+      setDragSourceVoices(null);
+      applyDragAction('erase', measureIndex, rowIndex, position);
+    }
+  }, [getVoicesForPosition, applyDragAction]);
+
+  const handleMouseEnter = useCallback((
+    measureIndex: number,
+    rowIndex: number,
+    position: number
+  ) => {
+    if (isDragging && dragMode && measureIndex === dragMeasureIndex) {
+      applyDragAction(dragMode, measureIndex, rowIndex, position, dragSourceVoices || undefined);
+    }
+  }, [isDragging, dragMode, dragMeasureIndex, dragSourceVoices, applyDragAction]);
+
+  const handleTouchStart = useCallback((
+    _event: React.TouchEvent,
+    measureIndex: number,
+    rowIndex: number,
+    position: number
+  ) => {
+    setTouchStartTime(Date.now());
+    setTouchMoved(false);
+    const sourceVoices = getVoicesForPosition(measureIndex, rowIndex, position);
+    setIsDragging(true);
+    setDragMode('paint');
+    setDragMeasureIndex(measureIndex);
+    setDragSourceVoices(sourceVoices);
+    applyDragAction('paint', measureIndex, rowIndex, position, sourceVoices);
+  }, [getVoicesForPosition, applyDragAction]);
+
+  const handleTouchMove = useCallback((event: React.TouchEvent) => {
+    setTouchMoved(true);
+    if (!isDragging) return;
+
+    const touch = event.touches[0];
+    const element = document.elementFromPoint(touch.clientX, touch.clientY);
+
+    if (element && (element.classList.contains('note-cell') || element.classList.contains('drum-cell'))) {
+      const cellButton = element as HTMLButtonElement;
+      const mIdx = parseInt(cellButton.dataset.measureIndex || '-1');
+      const rIdx = parseInt(cellButton.dataset.rowIndex || '-1');
+      const pos = parseInt(cellButton.dataset.position || '-1');
+
+      if (mIdx >= 0 && rIdx >= 0 && pos >= 0 && dragMode && mIdx === dragMeasureIndex) {
+        applyDragAction(dragMode, mIdx, rIdx, pos, dragSourceVoices || undefined);
+      }
+    }
+  }, [isDragging, dragMode, dragMeasureIndex, dragSourceVoices, applyDragAction]);
+
+  const handleTouchEnd = useCallback((
+    event: React.TouchEvent,
+    measureIndex: number,
+    rowIndex: number,
+    position: number
+  ) => {
+    const touchDuration = Date.now() - touchStartTime;
+
+    if (touchDuration > 500 && !touchMoved) {
+      event.preventDefault();
+      const row = DRUM_ROWS[rowIndex];
+      if (row.variations.length > 1) {
+        const menuPosition = getContextMenuPosition(event.currentTarget, rowIndex);
+        setContextMenu({
+          visible: true,
+          ...menuPosition,
+          rowIndex,
+          position,
+          measureIndex,
+        });
+      }
+    }
+
+    setIsDragging(false);
+    setDragMode(null);
+    setDragSourceVoices(null);
+    setTouchMoved(false);
+  }, [touchStartTime, touchMoved, getContextMenuPosition, setContextMenu]);
+
+  // End drag on global mouseup
+  useEffect(() => {
+    const handleMouseUp = () => {
+      if (isDragging) {
+        setIsDragging(false);
+        setDragMode(null);
+        setDragSourceVoices(null);
+      }
+    };
+
+    document.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [isDragging]);
+
+  return {
+    isDragging,
+    dragMode,
+    applyDragAction,
+    handleMouseDown,
+    handleMouseEnter,
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+  };
+}

--- a/src/hooks/useKeyboardEditor.ts
+++ b/src/hooks/useKeyboardEditor.ts
@@ -1,0 +1,423 @@
+/**
+ * useKeyboardEditor Hook
+ *
+ * Manages keyboard navigation state for the drum grid editor:
+ * cursor position (row/col/measure), variation menu selection,
+ * keyboard messages, and the full handleKeyboardEditKeyDown handler.
+ */
+
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { GrooveData, DrumVoice, MAX_MEASURES } from '../types';
+import { GrooveUtils } from '../core';
+import { DRUM_ROWS, NoteChange } from './useDrumGrid';
+import type { UseDrumGridReturn } from './useDrumGrid';
+
+export interface KeyboardCursor {
+  measureIndex: number;
+  rowIndex: number;
+  position: number;
+}
+
+const INITIAL_KEYBOARD_ROW_INDEX = Math.max(0, DRUM_ROWS.findIndex(row => row.name === 'Hi-Hat'));
+
+export interface UseKeyboardEditorProps {
+  groove: GrooveData;
+  grid: UseDrumGridReturn;
+  onNoteToggle: (voice: DrumVoice, position: number, measureIndex: number) => void;
+  onSetNotes?: (changes: NoteChange[]) => void;
+  onPreview: (voice: DrumVoice) => void;
+  onMeasureCopy?: (measureIndex: number) => void;
+  onMeasurePaste?: (afterIndex: number) => boolean;
+}
+
+export interface UseKeyboardEditorReturn {
+  keyboardCursor: KeyboardCursor;
+  keyboardVariationIndex: number;
+  keyboardMessage: string | null;
+  cellRefs: React.MutableRefObject<Record<string, HTMLButtonElement | null>>;
+  getCellKey: (cursor: KeyboardCursor) => string;
+  registerCellRef: (cursor: KeyboardCursor, element: HTMLButtonElement | null) => void;
+  handleKeyboardEditKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void;
+  handleKeyboardVariationSelect: (variationIndex: number) => void;
+  setKeyboardCursor: React.Dispatch<React.SetStateAction<KeyboardCursor>>;
+}
+
+export function useKeyboardEditor({
+  groove,
+  grid,
+  onNoteToggle,
+  onSetNotes,
+  onPreview,
+  onMeasureCopy,
+  onMeasurePaste,
+}: UseKeyboardEditorProps): UseKeyboardEditorReturn {
+  const [keyboardCursor, setKeyboardCursor] = useState<KeyboardCursor>({
+    measureIndex: 0,
+    rowIndex: INITIAL_KEYBOARD_ROW_INDEX,
+    position: 0,
+  });
+  const [keyboardVariationIndex, setKeyboardVariationIndex] = useState(0);
+  const [keyboardMessage, setKeyboardMessage] = useState<string | null>(null);
+  const cellRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const keyboardMessageTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const getCellKey = useCallback((cursor: KeyboardCursor) => {
+    return `${cursor.measureIndex}-${cursor.rowIndex}-${cursor.position}`;
+  }, []);
+
+  const registerCellRef = useCallback((cursor: KeyboardCursor, element: HTMLButtonElement | null) => {
+    cellRefs.current[getCellKey(cursor)] = element;
+  }, [getCellKey]);
+
+  const getPositionCount = useCallback((measureIndex: number) => {
+    const measure = groove.measures[measureIndex];
+    const ts = measure?.timeSignature || groove.timeSignature;
+    return GrooveUtils.calcNotesPerMeasure(groove.division, ts.beats, ts.noteValue);
+  }, [groove.division, groove.measures, groove.timeSignature]);
+
+  const getHorizontalNeighbor = useCallback((cursor: KeyboardCursor, direction: -1 | 1): KeyboardCursor | null => {
+    const positionCount = getPositionCount(cursor.measureIndex);
+    const nextPosition = cursor.position + direction;
+
+    if (nextPosition >= 0 && nextPosition < positionCount) {
+      return { ...cursor, position: nextPosition };
+    }
+
+    const nextMeasureIndex = cursor.measureIndex + direction;
+    if (nextMeasureIndex < 0 || nextMeasureIndex >= groove.measures.length) {
+      return null;
+    }
+
+    return {
+      measureIndex: nextMeasureIndex,
+      rowIndex: cursor.rowIndex,
+      position: direction === 1 ? 0 : getPositionCount(nextMeasureIndex) - 1,
+    };
+  }, [getPositionCount, groove.measures.length]);
+
+  const moveKeyboardCursor = useCallback((direction: 'up' | 'down' | 'left' | 'right') => {
+    setKeyboardCursor(current => {
+      if (direction === 'left' || direction === 'right') {
+        return getHorizontalNeighbor(current, direction === 'right' ? 1 : -1) || current;
+      }
+
+      const nextRowIndex = Math.min(
+        DRUM_ROWS.length - 1,
+        Math.max(0, current.rowIndex + (direction === 'down' ? 1 : -1))
+      );
+
+      return { ...current, rowIndex: nextRowIndex };
+    });
+  }, [getHorizontalNeighbor]);
+
+  const getRowVoices = useCallback((cursor: KeyboardCursor) => {
+    const measure = groove.measures[cursor.measureIndex];
+    if (!measure) return [];
+    const row = DRUM_ROWS[cursor.rowIndex];
+    const activeVoices: DrumVoice[] = [];
+    row.variations.forEach(variation => {
+      variation.voices.forEach(voice => {
+        if (measure.notes[voice]?.[cursor.position] && !activeVoices.includes(voice)) {
+          activeVoices.push(voice);
+        }
+      });
+    });
+    return activeVoices;
+  }, [groove.measures]);
+
+  const setRowVoices = useCallback((cursor: KeyboardCursor, voices: DrumVoice[]) => {
+    const measure = groove.measures[cursor.measureIndex];
+    if (!measure) return;
+
+    const row = DRUM_ROWS[cursor.rowIndex];
+    const changes: NoteChange[] = [];
+
+    row.variations.forEach(variation => {
+      variation.voices.forEach(voice => {
+        if (measure.notes[voice]?.[cursor.position]) {
+          changes.push({
+            voice,
+            position: cursor.position,
+            measureIndex: cursor.measureIndex,
+            value: false,
+          });
+        }
+      });
+    });
+
+    voices.forEach(voice => {
+      changes.push({
+        voice,
+        position: cursor.position,
+        measureIndex: cursor.measureIndex,
+        value: true,
+      });
+    });
+
+    if (changes.length === 0) return;
+
+    if (onSetNotes) {
+      onSetNotes(changes);
+    } else {
+      changes.forEach(change => {
+        if (measure.notes[change.voice]?.[change.position] !== change.value) {
+          onNoteToggle(change.voice, change.position, change.measureIndex);
+        }
+      });
+    }
+
+    if (voices[0]) {
+      onPreview(voices[0]);
+    }
+  }, [groove.measures, onNoteToggle, onPreview, onSetNotes]);
+
+  const toggleKeyboardCell = useCallback(() => {
+    const activeVoices = getRowVoices(keyboardCursor);
+    setRowVoices(
+      keyboardCursor,
+      activeVoices.length > 0 ? [] : DRUM_ROWS[keyboardCursor.rowIndex].defaultVoices
+    );
+  }, [getRowVoices, keyboardCursor, setRowVoices]);
+
+  const duplicateKeyboardCell = useCallback((direction: -1 | 1) => {
+    const target = getHorizontalNeighbor(keyboardCursor, direction);
+    if (!target) return;
+
+    const sourceVoices = getRowVoices(keyboardCursor);
+    if (sourceVoices.length === 0) return;
+
+    setRowVoices(target, sourceVoices);
+    setKeyboardCursor(target);
+  }, [getHorizontalNeighbor, getRowVoices, keyboardCursor, setRowVoices]);
+
+  const eraseKeyboardCell = useCallback((direction: -1 | 1) => {
+    const target = getHorizontalNeighbor(keyboardCursor, direction);
+    if (!target) return;
+
+    setRowVoices(target, []);
+    setKeyboardCursor(target);
+  }, [getHorizontalNeighbor, keyboardCursor, setRowVoices]);
+
+  const openKeyboardVariationMenu = useCallback(() => {
+    const row = DRUM_ROWS[keyboardCursor.rowIndex];
+    if (row.variations.length <= 1) return;
+
+    const cell = cellRefs.current[getCellKey(keyboardCursor)];
+    if (!cell) return;
+
+    const rect = cell.getBoundingClientRect();
+    const menuWidth = 200;
+    const menuHeight = 34 + row.variations.length * 38 + 8;
+    const gap = 6;
+    const viewportPadding = 8;
+    const roomBelow = window.innerHeight - rect.bottom - gap - viewportPadding;
+    const roomAbove = rect.top - gap - viewportPadding;
+    const hasRoomBelow = roomBelow >= menuHeight;
+    const hasRoomAbove = roomAbove >= menuHeight;
+    const placement = hasRoomBelow || (!hasRoomAbove && roomBelow >= roomAbove) ? 'below' : 'above';
+    const selectedVoices = grid.getVoicesForPosition(
+      keyboardCursor.measureIndex,
+      keyboardCursor.rowIndex,
+      keyboardCursor.position
+    );
+    const selectedIndex = Math.max(0, row.variations.findIndex(variation =>
+      variation.voices.length === selectedVoices.length &&
+      variation.voices.every(voice => selectedVoices.includes(voice))
+    ));
+
+    setKeyboardVariationIndex(selectedIndex);
+    grid.setContextMenu({
+      visible: true,
+      x: Math.min(
+        Math.max(rect.left, viewportPadding),
+        window.innerWidth - menuWidth - viewportPadding
+      ),
+      y: placement === 'below'
+        ? rect.bottom + gap
+        : rect.top - menuHeight - gap,
+      placement,
+      rowIndex: keyboardCursor.rowIndex,
+      position: keyboardCursor.position,
+      measureIndex: keyboardCursor.measureIndex,
+    });
+  }, [getCellKey, grid, keyboardCursor]);
+
+  const handleKeyboardVariationSelect = useCallback((variationIndex: number) => {
+    const row = DRUM_ROWS[keyboardCursor.rowIndex];
+    const variation = row.variations[variationIndex];
+    if (!variation) return;
+
+    setKeyboardVariationIndex(variationIndex);
+    grid.handleVoiceSelect(variation.voices);
+  }, [grid, keyboardCursor.rowIndex]);
+
+  const isEditableTarget = useCallback((target: EventTarget | null) => {
+    if (!(target instanceof HTMLElement)) return false;
+    return Boolean(target.closest('input, textarea, select, [contenteditable="true"]'));
+  }, []);
+
+  const handleKeyboardEditKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (isEditableTarget(event.target)) return;
+
+    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'c') {
+      event.preventDefault();
+      onMeasureCopy?.(keyboardCursor.measureIndex);
+      return;
+    }
+
+    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'v') {
+      event.preventDefault();
+      const pasted = onMeasurePaste?.(keyboardCursor.measureIndex) ?? false;
+      if (pasted) {
+        setKeyboardMessage(null);
+        setKeyboardCursor(current => ({
+          ...current,
+          measureIndex: Math.min(current.measureIndex + 1, groove.measures.length),
+        }));
+      } else {
+        setKeyboardMessage(
+          groove.measures.length >= MAX_MEASURES
+            ? `Measure limit reached (${MAX_MEASURES}). Cannot paste more measures.`
+            : 'Copy a measure before pasting.'
+        );
+      }
+      return;
+    }
+
+    if (grid.contextMenu?.visible) {
+      const row = DRUM_ROWS[grid.contextMenu.rowIndex];
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault();
+        setKeyboardVariationIndex(current => {
+          const delta = event.key === 'ArrowDown' ? 1 : -1;
+          return (current + delta + row.variations.length) % row.variations.length;
+        });
+        return;
+      }
+
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        handleKeyboardVariationSelect(keyboardVariationIndex);
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        grid.setContextMenu(null);
+        return;
+      }
+    }
+
+    if (
+      (event.shiftKey || event.altKey) &&
+      (event.key === 'ArrowLeft' || event.key === 'ArrowRight')
+    ) {
+      event.preventDefault();
+      eraseKeyboardCell(event.key === 'ArrowRight' ? 1 : -1);
+      return;
+    }
+
+    if (
+      (event.ctrlKey || event.metaKey) &&
+      (event.key === 'ArrowLeft' || event.key === 'ArrowRight')
+    ) {
+      event.preventDefault();
+      duplicateKeyboardCell(event.key === 'ArrowRight' ? 1 : -1);
+      return;
+    }
+
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowRight' || event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+      event.preventDefault();
+      const direction = event.key.replace('Arrow', '').toLowerCase() as 'up' | 'down' | 'left' | 'right';
+      moveKeyboardCursor(direction);
+      return;
+    }
+
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      toggleKeyboardCell();
+      return;
+    }
+
+    if (event.key === 'Tab') {
+      event.preventDefault();
+      openKeyboardVariationMenu();
+    }
+  }, [
+    duplicateKeyboardCell,
+    eraseKeyboardCell,
+    grid,
+    groove.measures.length,
+    handleKeyboardVariationSelect,
+    isEditableTarget,
+    keyboardCursor,
+    keyboardVariationIndex,
+    moveKeyboardCursor,
+    onMeasureCopy,
+    onMeasurePaste,
+    openKeyboardVariationMenu,
+    toggleKeyboardCell,
+  ]);
+
+  // Clamp cursor when measures are removed or time signatures change
+  useEffect(() => {
+    setKeyboardCursor(current => {
+      const maxMeasureIndex = Math.max(0, groove.measures.length - 1);
+      const maxRowIndex = DRUM_ROWS.length - 1;
+
+      if (
+        current.measureIndex <= maxMeasureIndex &&
+        current.rowIndex <= maxRowIndex &&
+        current.position < getPositionCount(current.measureIndex)
+      ) {
+        return current;
+      }
+
+      const measureIndex = Math.min(current.measureIndex, maxMeasureIndex);
+      const position = Math.min(current.position, Math.max(0, getPositionCount(measureIndex) - 1));
+      const rowIndex = Math.min(current.rowIndex, maxRowIndex);
+      return { measureIndex, rowIndex, position };
+    });
+  }, [getPositionCount, groove.measures.length]);
+
+  // Focus cell and scroll into view when cursor moves
+  useEffect(() => {
+    const cell = cellRefs.current[getCellKey(keyboardCursor)];
+    if (cell && document.activeElement?.closest('[data-keyboard-editor="true"]')) {
+      cell.focus({ preventScroll: true });
+      cell.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    }
+  }, [getCellKey, keyboardCursor]);
+
+  // Auto-clear keyboard message after 2.5 seconds
+  useEffect(() => {
+    if (!keyboardMessage) return;
+
+    if (keyboardMessageTimerRef.current) {
+      clearTimeout(keyboardMessageTimerRef.current);
+    }
+    keyboardMessageTimerRef.current = setTimeout(() => {
+      setKeyboardMessage(null);
+      keyboardMessageTimerRef.current = null;
+    }, 2500);
+
+    return () => {
+      if (keyboardMessageTimerRef.current) {
+        clearTimeout(keyboardMessageTimerRef.current);
+        keyboardMessageTimerRef.current = null;
+      }
+    };
+  }, [keyboardMessage]);
+
+  return {
+    keyboardCursor,
+    keyboardVariationIndex,
+    keyboardMessage,
+    cellRefs,
+    getCellKey,
+    registerCellRef,
+    handleKeyboardEditKeyDown,
+    handleKeyboardVariationSelect,
+    setKeyboardCursor,
+  };
+}

--- a/src/hooks/useMeasureCopyPaste.ts
+++ b/src/hooks/useMeasureCopyPaste.ts
@@ -1,0 +1,50 @@
+import { useRef, useCallback } from 'react';
+import { GrooveData, MeasureConfig, MAX_MEASURES } from '../types';
+
+export interface MeasureCopyPasteReturn {
+  handleMeasureCopy: (measureIndex: number) => void;
+  handleMeasurePaste: (afterIndex: number) => boolean;
+}
+
+function cloneMeasure(measure: MeasureConfig): MeasureConfig {
+  return {
+    ...measure,
+    notes: Object.fromEntries(
+      Object.entries(measure.notes).map(([voice, notes]) => [voice, [...notes]])
+    ) as MeasureConfig['notes'],
+    sticking: measure.sticking ? [...measure.sticking] : undefined,
+  };
+}
+
+export function useMeasureCopyPaste(
+  groove: GrooveData,
+  setGroove: (g: GrooveData) => void
+): MeasureCopyPasteReturn {
+  const copiedMeasureRef = useRef<MeasureConfig | null>(null);
+
+  const handleMeasureCopy = useCallback((measureIndex: number) => {
+    const measure = groove.measures[measureIndex];
+    if (!measure) return;
+    copiedMeasureRef.current = cloneMeasure(measure);
+  }, [groove.measures]);
+
+  const handleMeasurePaste = useCallback((afterIndex: number): boolean => {
+    if (!copiedMeasureRef.current || groove.measures.length >= MAX_MEASURES) {
+      return false;
+    }
+
+    const measureToPaste = cloneMeasure(copiedMeasureRef.current);
+    const insertIndex = Math.min(afterIndex + 1, groove.measures.length);
+    setGroove({
+      ...groove,
+      measures: [
+        ...groove.measures.slice(0, insertIndex),
+        measureToPaste,
+        ...groove.measures.slice(insertIndex),
+      ],
+    });
+    return true;
+  }, [groove, setGroove]);
+
+  return { handleMeasureCopy, handleMeasurePaste };
+}

--- a/src/hooks/useModalState.ts
+++ b/src/hooks/useModalState.ts
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+
+export interface ModalState {
+  isDownloadModalOpen: boolean;
+  setIsDownloadModalOpen: (open: boolean) => void;
+  isPrintModalOpen: boolean;
+  setIsPrintModalOpen: (open: boolean) => void;
+  isMyGroovesModalOpen: boolean;
+  setIsMyGroovesModalOpen: (open: boolean) => void;
+  isSaveGrooveModalOpen: boolean;
+  setIsSaveGrooveModalOpen: (open: boolean) => void;
+  isGrooveLibraryModalOpen: boolean;
+  setIsGrooveLibraryModalOpen: (open: boolean) => void;
+  isShareModalOpen: boolean;
+  setIsShareModalOpen: (open: boolean) => void;
+  isTimeSignatureModalOpen: boolean;
+  setIsTimeSignatureModalOpen: (open: boolean) => void;
+}
+
+export function useModalState(): ModalState {
+  const [isDownloadModalOpen, setIsDownloadModalOpen] = useState(false);
+  const [isPrintModalOpen, setIsPrintModalOpen] = useState(false);
+  const [isMyGroovesModalOpen, setIsMyGroovesModalOpen] = useState(false);
+  const [isSaveGrooveModalOpen, setIsSaveGrooveModalOpen] = useState(false);
+  const [isGrooveLibraryModalOpen, setIsGrooveLibraryModalOpen] = useState(false);
+  const [isShareModalOpen, setIsShareModalOpen] = useState(false);
+  const [isTimeSignatureModalOpen, setIsTimeSignatureModalOpen] = useState(false);
+
+  return {
+    isDownloadModalOpen,
+    setIsDownloadModalOpen,
+    isPrintModalOpen,
+    setIsPrintModalOpen,
+    isMyGroovesModalOpen,
+    setIsMyGroovesModalOpen,
+    isSaveGrooveModalOpen,
+    setIsSaveGrooveModalOpen,
+    isGrooveLibraryModalOpen,
+    setIsGrooveLibraryModalOpen,
+    isShareModalOpen,
+    setIsShareModalOpen,
+    isTimeSignatureModalOpen,
+    setIsTimeSignatureModalOpen,
+  };
+}

--- a/src/hooks/usePlaybackState.ts
+++ b/src/hooks/usePlaybackState.ts
@@ -1,0 +1,163 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { GrooveData, DrumVoice, MetronomeConfig } from '../types';
+import * as analytics from '../utils/analytics';
+
+interface AutoSpeedUp {
+  isActive: boolean;
+  start: () => void;
+  stop: () => void;
+}
+
+interface UsePlaybackStateParams {
+  groove: GrooveData;
+  play: (groove: GrooveData) => Promise<void>;
+  stop: () => void;
+  isPlaying: boolean;
+  metronomeConfig: MetronomeConfig;
+  autoSpeedUp: AutoSpeedUp;
+  playPreview: (voice: DrumVoice) => Promise<void>;
+}
+
+export interface PlaybackStateReturn {
+  elapsedTime: string;
+  isCountingIn: boolean;
+  countdownNumber: number | null;
+  countingInButton: 'play' | 'playPlus' | null;
+  handlePlay: () => Promise<void>;
+  handlePlayWithSpeedUp: () => Promise<void>;
+}
+
+export function usePlaybackState({
+  groove,
+  play,
+  stop,
+  isPlaying,
+  metronomeConfig,
+  autoSpeedUp,
+  playPreview,
+}: UsePlaybackStateParams): PlaybackStateReturn {
+  const [elapsedTime, setElapsedTime] = useState('0:00');
+  const [isCountingIn, setIsCountingIn] = useState(false);
+  const [countdownNumber, setCountdownNumber] = useState<number | null>(null);
+  const [countingInButton, setCountingInButton] = useState<'play' | 'playPlus' | null>(null);
+
+  const playStartTimeRef = useRef<number | null>(null);
+  const countInTimeoutRef = useRef<number | null>(null);
+
+  // Track elapsed time during playback
+  useEffect(() => {
+    if (isPlaying) {
+      playStartTimeRef.current = Date.now();
+
+      const updateElapsedTime = () => {
+        if (playStartTimeRef.current) {
+          const elapsed = Date.now() - playStartTimeRef.current;
+          const seconds = Math.floor(elapsed / 1000);
+          const minutes = Math.floor(seconds / 60);
+          const remainingSeconds = seconds % 60;
+          setElapsedTime(`${minutes}:${remainingSeconds.toString().padStart(2, '0')}`);
+        }
+      };
+
+      const intervalId = setInterval(updateElapsedTime, 100);
+      updateElapsedTime();
+
+      return () => {
+        clearInterval(intervalId);
+      };
+    } else {
+      playStartTimeRef.current = null;
+      setElapsedTime('0:00');
+    }
+  }, [isPlaying]);
+
+  const cancelCountIn = useCallback(() => {
+    if (countInTimeoutRef.current) {
+      clearTimeout(countInTimeoutRef.current);
+      countInTimeoutRef.current = null;
+    }
+    setIsCountingIn(false);
+    setCountdownNumber(null);
+    setCountingInButton(null);
+  }, []);
+
+  const playCountIn = useCallback(async (button: 'play' | 'playPlus'): Promise<boolean> => {
+    return new Promise((resolve) => {
+      const beatDuration = 60000 / groove.tempo;
+      let currentBeat = 4;
+
+      setIsCountingIn(true);
+      setCountingInButton(button);
+      setCountdownNumber(currentBeat);
+
+      const playBeat = () => {
+        if (currentBeat > 0) {
+          playPreview('hihat-metronome-normal');
+          setCountdownNumber(currentBeat);
+          currentBeat--;
+          countInTimeoutRef.current = window.setTimeout(playBeat, beatDuration);
+        } else {
+          setIsCountingIn(false);
+          setCountdownNumber(null);
+          setCountingInButton(null);
+          resolve(true);
+        }
+      };
+
+      playBeat();
+    });
+  }, [groove.tempo, playPreview]);
+
+  const handlePlay = useCallback(async () => {
+    if (autoSpeedUp.isActive) autoSpeedUp.stop();
+
+    if (isCountingIn) {
+      cancelCountIn();
+      return;
+    }
+
+    if (isPlaying) {
+      const duration = playStartTimeRef.current ? (Date.now() - playStartTimeRef.current) / 1000 : 0;
+      analytics.trackStop('normal', duration);
+      stop();
+    } else {
+      if (metronomeConfig.countIn) {
+        const completed = await playCountIn('play');
+        if (!completed) return;
+      }
+      analytics.trackPlay('normal', groove.tempo, `${groove.timeSignature.beats}/${groove.timeSignature.noteValue}`);
+      await play(groove);
+    }
+  }, [autoSpeedUp, isCountingIn, cancelCountIn, isPlaying, stop, metronomeConfig.countIn, playCountIn, groove, play]);
+
+  const handlePlayWithSpeedUp = useCallback(async () => {
+    if (isCountingIn) {
+      cancelCountIn();
+      return;
+    }
+
+    if (isPlaying) {
+      const duration = playStartTimeRef.current ? (Date.now() - playStartTimeRef.current) / 1000 : 0;
+      analytics.trackStop('speed-up', duration);
+      autoSpeedUp.stop();
+      stop();
+    } else {
+      if (metronomeConfig.countIn) {
+        const completed = await playCountIn('playPlus');
+        if (!completed) return;
+      }
+      analytics.trackPlay('speed-up', groove.tempo, `${groove.timeSignature.beats}/${groove.timeSignature.noteValue}`);
+      await play(groove);
+      autoSpeedUp.start();
+    }
+  }, [isCountingIn, cancelCountIn, isPlaying, autoSpeedUp, stop, metronomeConfig.countIn, playCountIn, groove, play]);
+
+  return {
+    elapsedTime,
+    isCountingIn,
+    countdownNumber,
+    countingInButton,
+    handlePlay,
+    handlePlayWithSpeedUp,
+  };
+}

--- a/src/hooks/useStickingState.ts
+++ b/src/hooks/useStickingState.ts
@@ -1,0 +1,76 @@
+import { useState, useCallback } from 'react';
+import { GrooveData, StickingValue, createEmptySticking } from '../types';
+import { GrooveUtils } from '../core';
+import { applyStickingToSimilar } from '../core/stickingUtils';
+
+export interface StickingStateReturn {
+  isStickingSetupActive: boolean;
+  handleStickingSetupToggle: () => void;
+  handleStickingChange: (measureIndex: number, subdivIndex: number, value: StickingValue) => void;
+  handleApplyToSimilar: (measureIndex: number) => string;
+}
+
+export function useStickingState(
+  groove: GrooveData,
+  setGroove: (g: GrooveData) => void
+): StickingStateReturn {
+  const [isStickingSetupActive, setIsStickingSetupActive] = useState(false);
+
+  const handleStickingSetupToggle = useCallback(() => {
+    setIsStickingSetupActive(prev => !prev);
+  }, []);
+
+  const handleStickingChange = useCallback((
+    measureIndex: number,
+    subdivIndex: number,
+    value: StickingValue
+  ) => {
+    const measure = groove.measures[measureIndex];
+    if (!measure) return;
+
+    const ts = measure.timeSignature || groove.timeSignature;
+    const subdivCount = GrooveUtils.calcNotesPerMeasure(groove.division, ts.beats, ts.noteValue);
+
+    if (subdivIndex < 0 || subdivIndex >= subdivCount) return;
+
+    const existingSticking: StickingValue[] = (measure.sticking && measure.sticking.length === subdivCount)
+      ? [...measure.sticking]
+      : createEmptySticking(subdivCount);
+
+    existingSticking[subdivIndex] = value;
+
+    setGroove({
+      ...groove,
+      measures: groove.measures.map((m, i) =>
+        i === measureIndex ? { ...m, sticking: existingSticking } : m
+      ),
+    });
+  }, [groove, setGroove]);
+
+  const handleApplyToSimilar = useCallback((measureIndex: number): string => {
+    const similarIndices = applyStickingToSimilar(groove, measureIndex);
+    if (similarIndices.length === 0) {
+      return 'No similar measures found.';
+    }
+
+    const sourceSticking = groove.measures[measureIndex].sticking!;
+    setGroove({
+      ...groove,
+      measures: groove.measures.map((m, i) =>
+        similarIndices.includes(i)
+          ? { ...m, sticking: [...sourceSticking] }
+          : m
+      ),
+    });
+
+    const count = similarIndices.length;
+    return `Applied to ${count} similar ${count === 1 ? 'measure' : 'measures'}.`;
+  }, [groove, setGroove]);
+
+  return {
+    isStickingSetupActive,
+    handleStickingSetupToggle,
+    handleStickingChange,
+    handleApplyToSimilar,
+  };
+}

--- a/src/midi/BPMEstimator.ts
+++ b/src/midi/BPMEstimator.ts
@@ -1,0 +1,94 @@
+/**
+ * BPMEstimator - EWMA-smoothed performed BPM estimation using inter-onset intervals.
+ * Spec Section 7: Track tempo drift relative to grid.
+ *
+ * Method: for each accepted hit compute its absolute quantized step index
+ *   absStep = round((timestamp - startTime) / stepDurMs)
+ * then use the step delta between consecutive accepted hits to estimate BPM.
+ * Correct even when the drummer plays quarters in a 16ths groove because
+ * stepDelta reflects actual steps skipped, not a raw hit count.
+ *
+ * Flam/simultaneous hits (stepDelta=0): skip EWMA update entirely,
+ * keeping last* unchanged so the next genuine onset measures from the real previous hit.
+ *
+ * getPerformedBpm() returns null when |estimate - tempo|/tempo > 0.2,
+ * but the internal estimate is NOT zeroed — preventing oscillation.
+ */
+export class BPMEstimator {
+  private readonly EWMA_ALPHA = 0.05;
+  private bpmEstimate: number | null = null;
+  private lastAbsStep: number | null = null;
+  private lastTimestamp: number | null = null;
+
+  reset(): void {
+    this.bpmEstimate = null;
+    this.lastAbsStep = null;
+    this.lastTimestamp = null;
+  }
+
+  /**
+   * Update estimate from a new accepted hit.
+   * @param timestamp - Hit timestamp (ms)
+   * @param startTime - Playback start time (ms, same clock as timestamp)
+   * @param tempo - Current grid tempo (BPM)
+   * @param division - Groove division (e.g. 16 for 16th notes)
+   */
+  update(timestamp: number, startTime: number, tempo: number, division: number): void {
+    // Beat = quarter note (engine source of truth: note duration = (60/tempo)/(division/4))
+    const stepsPerBeat = division / 4;
+    const beatDurMs = (60 / tempo) * 1000;
+    const stepDurMs = beatDurMs / stepsPerBeat;
+
+    const absStep = Math.round((timestamp - startTime) / stepDurMs);
+
+    if (this.lastAbsStep === null || this.lastTimestamp === null) {
+      this.lastAbsStep = absStep;
+      this.lastTimestamp = timestamp;
+      return;
+    }
+
+    const stepDelta = absStep - this.lastAbsStep;
+
+    if (stepDelta < 1) {
+      // Simultaneous / flam hit: skip update, keep last* unchanged
+      return;
+    }
+
+    if (stepDelta < stepsPerBeat) {
+      // Sub-beat interval: too short to measure BPM accurately
+      this.lastAbsStep = absStep;
+      this.lastTimestamp = timestamp;
+      return;
+    }
+
+    const timeDeltaSecs = (timestamp - this.lastTimestamp) / 1000;
+    if (timeDeltaSecs <= 0) {
+      this.lastAbsStep = absStep;
+      this.lastTimestamp = timestamp;
+      return;
+    }
+
+    const bpmSample = (stepDelta * 60) / (stepsPerBeat * timeDeltaSecs);
+
+    if (this.bpmEstimate === null) {
+      this.bpmEstimate = bpmSample;
+    } else {
+      this.bpmEstimate += this.EWMA_ALPHA * (bpmSample - this.bpmEstimate);
+    }
+
+    this.lastAbsStep = absStep;
+    this.lastTimestamp = timestamp;
+  }
+
+  /**
+   * Get smoothed BPM estimate. Returns null if deviation from set tempo
+   * exceeds 20% or insufficient data collected yet.
+   * The internal estimate is NOT nulled on deviation — prevents oscillation (#122).
+   */
+  getPerformedBpm(tempo: number): number | null {
+    if (this.bpmEstimate === null) return null;
+    const deviation = Math.abs(this.bpmEstimate - tempo) / tempo;
+    if (deviation > 0.2) return null;
+    return Math.round(this.bpmEstimate * 10) / 10;
+  }
+}

--- a/src/midi/PerformanceTracker.ts
+++ b/src/midi/PerformanceTracker.ts
@@ -4,7 +4,7 @@
  * Tracks performance metrics when playing along with loaded groove patterns.
  * - Step-level quantization with swing-aware offset grids (Spec Section 4-5)
  * - Tempo-aware grading bands that scale with BPM (Spec Section 6)
- * - EWMA-smoothed performed BPM estimation (Spec Section 7)
+ * - EWMA-smoothed performed BPM estimation delegated to BPMEstimator (Spec Section 7)
  * - Signed timing errors (negative=slow, positive=fast)
  *
  * Spec: https://github.com/AdarBahar/portfolio-tracker/issues/264
@@ -13,6 +13,13 @@
 import { DrumVoice, GrooveData, getFlattenedNotes } from '../types';
 import { GrooveUtils } from '../core/GrooveUtils';
 import { logger } from '../utils/logger';
+import { BPMEstimator } from './BPMEstimator';
+import {
+  calculateTimingError,
+  calculateTimingAccuracy,
+  checkNoteAccuracy,
+  getFeedback,
+} from './performanceGrader';
 
 export interface PerformanceStats {
   totalHits: number;
@@ -49,19 +56,13 @@ class PerformanceTracker {
   private tempo: number = 120;
   private division: number = 8;
   private timeSignature: TimeSignature = { beats: 4, noteValue: 4 };
-  private swing: number = 0; // 0-100 internal storage, maps to 0-0.33 ratio
-  private beatOffsets: number[] = []; // ms offsets within one beat (accounts for swing)
+  private swing: number = 0;
+  private beatOffsets: number[] = [];
 
-  // Total steps across all measures (for wrapping getCurrentStep)
   private totalSteps: number = 0;
-
-  // Performed BPM estimation (EWMA inter-onset method — #122)
-  // globalStepIndex is retained for legacy use; BPM estimation now uses inter-onset step intervals.
   private globalStepIndex: number = 0;
-  private bpmEstimate: number | null = null;
-  private lastAbsStep: number | null = null;   // absolute quantized step of last accepted hit
-  private lastTimestamp: number | null = null; // timestamp of last accepted hit
-  private readonly EWMA_ALPHA = 0.05; // smoothing factor
+
+  private readonly bpmEstimator = new BPMEstimator();
 
   private stats: PerformanceStats = {
     totalHits: 0,
@@ -77,19 +78,16 @@ class PerformanceTracker {
    *                    Must match clock source for hit timestamps (event.timeStamp from MIDI)
    */
   enable(groove: GrooveData, startTime: number): void {
-    // Validate tempo (Issue #94)
     if (!groove.tempo || groove.tempo <= 0) {
       logger.warn('PerformanceTracker: Invalid tempo. Must be positive number.');
       return;
     }
 
-    // Validate groove has required timing metadata
     if (!groove.division || !groove.timeSignature?.beats || !groove.timeSignature?.noteValue) {
       logger.warn('PerformanceTracker: Groove missing required timing metadata.');
       return;
     }
 
-    // Store all timing parameters
     this.tempo = groove.tempo;
     this.division = groove.division;
     this.swing = groove.swing;
@@ -103,17 +101,11 @@ class PerformanceTracker {
       voices: getFlattenedNotes(groove),
     };
 
-    // Compute total steps: sum of each measure's step count (respects per-measure time sig overrides)
     this.totalSteps = this.computeTotalSteps(groove);
-
-    // Build swing-aware quantization grid
     this.buildOffsetGrid();
 
-    // Reset performance state
     this.globalStepIndex = 0;
-    this.bpmEstimate = null;
-    this.lastAbsStep = null;
-    this.lastTimestamp = null;
+    this.bpmEstimator.reset();
     this.resetStats();
 
     this.enabled = true;
@@ -149,7 +141,6 @@ class PerformanceTracker {
 
   /**
    * Compute total step count across all measures, respecting per-measure time signature overrides.
-   * Each measure contributes GrooveUtils.calcNotesPerMeasure(division, beats, noteValue) steps.
    * @private
    */
   private computeTotalSteps(groove: GrooveData): number {
@@ -166,12 +157,10 @@ class PerformanceTracker {
    * Update groove pattern mid-session (for live editing during playback).
    * Rebuilds the flattened pattern, total step count, and offset grid.
    * Does NOT reset startTime or stats — preserves accumulated performance data.
-   * @param groove - Updated GrooveData
    */
   updateGroove(groove: GrooveData): void {
     if (!this.enabled) return;
 
-    // Validate like enable()
     if (!groove.tempo || groove.tempo <= 0) {
       logger.warn('PerformanceTracker.updateGroove: Invalid tempo.');
       return;
@@ -186,22 +175,18 @@ class PerformanceTracker {
     this.swing = groove.swing;
     this.timeSignature = groove.timeSignature;
 
-    // Rebuild flattened pattern and total step count
     this.loadedPattern = {
       division: groove.division,
       timeSignature: groove.timeSignature,
       voices: getFlattenedNotes(groove),
     };
     this.totalSteps = this.computeTotalSteps(groove);
-
-    // Rebuild offset grid with possibly new tempo/swing/division
     this.buildOffsetGrid();
-    // startTime, globalStepIndex, bpmEstimate, and stats are intentionally preserved
   }
 
   /**
-   * Build swing-aware beat offset grid for quantization
-   * Spec Section 3-4: Swing affects offbeat positions in even-step divisions
+   * Build swing-aware beat offset grid for quantization.
+   * Spec Section 3-4: Swing affects offbeat positions in even-step divisions.
    * @private
    */
   private buildOffsetGrid(): void {
@@ -210,26 +195,21 @@ class PerformanceTracker {
     // Do NOT use division/noteValue here — that would disagree with the engine in non-4/4 (#123).
     const stepsPerBeat = this.division / 4;
 
-    // Triplet divisions: 12, 24, 48 (don't support swing)
     const isTriplet = [12, 24, 48].includes(this.division);
-    // Only 8, 16, 32 support swing
     const supportsSwing = [8, 16, 32].includes(this.division);
 
     const offsets: number[] = [];
 
     for (let i = 0; i < stepsPerBeat; i++) {
       if (isTriplet || !supportsSwing || this.swing === 0) {
-        // Straight or triplet: linear grid
         offsets.push((i * beatDurMs) / stepsPerBeat);
       } else {
-        // Even steps stay on grid
         if (i % 2 === 0) {
           offsets.push((i * beatDurMs) / stepsPerBeat);
         } else {
           // Odd steps (offbeats) are swung
-          // Spec: swingRatio = (swing / 100) * 0.33; s = swing / 100
-          // offbeatFraction = 0.5 + s * (1/6)  → ranges 0.5 (straight) to 0.667 (full triplet)
-          const s = this.swing / 100; // 0-1
+          // Spec: offbeatFraction = 0.5 + s * (1/6) → ranges 0.5 (straight) to 0.667 (full triplet)
+          const s = this.swing / 100;
           const offbeatFraction = 0.5 + s * (1 / 6);
           const pairStart = Math.floor(i / 2) * (beatDurMs / (stepsPerBeat / 2));
           const pairLen = beatDurMs / (stepsPerBeat / 2);
@@ -239,47 +219,6 @@ class PerformanceTracker {
     }
 
     this.beatOffsets = offsets;
-  }
-
-  /**
-   * Calculate signed timing error and absolute error
-   * Spec Section 5: Quantize to nearest offset in beat grid
-   * @private
-   * @param timestamp - Hit timestamp
-   * @returns { errorMs: signed error (negative=slow, positive=fast), absError: absolute }
-   */
-  private calculateTimingError(timestamp: number): { errorMs: number; absError: number } {
-    if (this.startTime == null) return { errorMs: 0, absError: 0 };
-
-    const elapsedMs = timestamp - this.startTime;
-    const beatDurMs = (60 / this.tempo) * 1000;
-
-    // Find which beat we're in
-    const beatIndex = Math.floor(elapsedMs / beatDurMs);
-    const beatStart = beatIndex * beatDurMs;
-    const posInBeat = elapsedMs - beatStart;
-
-    // Find nearest offset in the grid.
-    // Also consider beatDurMs as the next beat's downbeat (offset === beatDurMs),
-    // so a hit just before the downbeat (e.g. posInBeat=490, beatDurMs=500)
-    // reports a small negative error (-10ms) instead of a large late error.
-    let minDist = Infinity;
-    let nearestOffset = 0;
-    for (const offset of this.beatOffsets) {
-      const dist = Math.abs(posInBeat - offset);
-      if (dist < minDist) {
-        minDist = dist;
-        nearestOffset = offset;
-      }
-    }
-    // Check next-beat downbeat candidate
-    const nextDownbeatDist = Math.abs(posInBeat - beatDurMs);
-    if (nextDownbeatDist < minDist) {
-      nearestOffset = beatDurMs;
-    }
-
-    const errorMs = posInBeat - nearestOffset; // signed: negative=slow, positive=fast
-    return { errorMs, absError: Math.abs(errorMs) };
   }
 
   /**
@@ -305,24 +244,26 @@ class PerformanceTracker {
       return null;
     }
 
-    const { errorMs: timingErrorMs, absError } = this.calculateTimingError(timestamp);
-    const timingAccuracy = this.calculateTimingAccuracy(timestamp);
+    const beatDurMs = (60 / this.tempo) * 1000;
+    const elapsedMs = timestamp - this.startTime!;
+    const beatIndex = Math.floor(elapsedMs / beatDurMs);
+    const posInBeat = elapsedMs - beatIndex * beatDurMs;
+
+    const { errorMs: timingErrorMs, absError } = calculateTimingError(posInBeat, beatDurMs, this.beatOffsets);
+    const timingAccuracy = calculateTimingAccuracy(absError, beatDurMs);
     const currentStep = this.getCurrentStep(timestamp);
-    const noteAccuracy = this.checkNoteAccuracy(grooveVoice, currentStep);
+    const noteAccuracy = checkNoteAccuracy(grooveVoice, currentStep, this.loadedPattern);
     const overall = (timingAccuracy + noteAccuracy) / 2;
 
-    // Update global step counter for BPM estimation
-    if (absError < 100) { // Only count "accepted" hits
+    if (absError < 100) {
       this.globalStepIndex++;
-      this.updatePerformedBpmEstimate(timestamp);
+      this.bpmEstimator.update(timestamp, this.startTime!, this.tempo, this.division);
     }
 
-    // Update stats
     this.stats.totalHits++;
     if (overall > 70) {
       this.stats.accurateHits++;
     }
-    // Keep rolling window of timing errors
     this.stats.timingScores.push(timingAccuracy);
     if (this.stats.timingScores.length > MAX_TIMING_ERRORS) {
       this.stats.timingScores.shift();
@@ -334,16 +275,14 @@ class PerformanceTracker {
       timingAccuracy: Math.round(timingAccuracy),
       noteAccuracy: Math.round(noteAccuracy),
       overall: Math.round(overall),
-      feedback: this.getFeedback(overall),
-      timingErrorMs, // signed error in ms
+      feedback: getFeedback(overall),
+      timingErrorMs,
     };
   }
 
   /**
    * Get current step position based on elapsed time
    * @private
-   * @param timestamp - Hit timestamp (ms since epoch)
-   * @returns Step index (0-based within measure)
    */
   private getCurrentStep(timestamp: number): number {
     if (this.startTime == null) return 0;
@@ -355,186 +294,22 @@ class PerformanceTracker {
     const stepDurationMs = beatDurationMs / stepsPerBeat;
 
     const stepNumber = Math.round(elapsedMs / stepDurationMs);
-    // Wrap by total steps across ALL measures (not just one measure's length)
     const wrapLength = this.totalSteps > 0 ? this.totalSteps : stepsPerBeat * this.timeSignature.beats;
     return stepNumber % wrapLength;
   }
 
   /**
-   * Calculate timing accuracy with tempo-aware thresholds
-   * Spec Section 6: Use tempo-aware grading bands
-   * @private
-   * @param timestamp - Hit timestamp
-   * @returns Accuracy percentage (0-100)
-   */
-  private calculateTimingAccuracy(timestamp: number): number {
-    if (this.startTime == null) return 50;
-
-    const { absError } = this.calculateTimingError(timestamp);
-    const beatDurMs = (60 / this.tempo) * 1000;
-
-    // Tempo-aware thresholds (Spec Section 6)
-    const acceptWindow = Math.min(90, beatDurMs * 0.18);
-    const onTimeMs = Math.min(25, beatDurMs * 0.05);
-
-    // Grading bands based on distance from target
-    if (absError > acceptWindow) {
-      // Miss: too far away
-      return 0;
-    } else if (absError <= onTimeMs) {
-      // Perfect: on time
-      return 100;
-    } else if (absError <= onTimeMs * 2) {
-      // Good: close
-      return 75;
-    } else if (absError <= acceptWindow * 0.55) {
-      // Fair: reasonable
-      return 50;
-    } else {
-      // Poor: getting off
-      return 25;
-    }
-  }
-
-  /**
-   * Check if the hit note matches the loaded pattern at the current step
-   * @private
-   * @param grooveVoice - Voice that was hit
-   * @param currentStep - Current step in the measure (0-based)
-   * @returns Accuracy percentage (0-100)
-   */
-  private checkNoteAccuracy(grooveVoice: DrumVoice, currentStep: number): number {
-    // Issue #89: Now position-aware (checks specific step, not just voice existence)
-    if (!this.loadedPattern || !this.loadedPattern.voices) {
-      return 50; // No pattern loaded, can't verify
-    }
-
-    const voicePattern = this.loadedPattern.voices[grooveVoice];
-
-    if (!voicePattern || voicePattern.length === 0) {
-      // Voice not in pattern at all
-      return 30;
-    }
-
-    // Check if this voice plays at the current step (position-aware)
-    const stepInMeasure = currentStep % voicePattern.length;
-    if (voicePattern[stepInMeasure]) {
-      // Voice plays at this step
-      return 80;
-    } else {
-      // Voice exists in pattern but not at this step (wrong position)
-      return 30;
-    }
-  }
-
-  /**
-   * Get performance feedback message
-   * @private
-   * @param accuracy - Overall accuracy (0-100)
-   * @returns Feedback message
-   */
-  private getFeedback(accuracy: number): string {
-    if (accuracy >= 90) return 'Perfect!';
-    if (accuracy >= 75) return 'Great!';
-    if (accuracy >= 60) return 'Good';
-    if (accuracy >= 40) return 'Keep trying';
-    return 'Miss';
-  }
-
-  /**
-   * Update EWMA-smoothed performed BPM estimate using inter-onset step intervals.
-   * Spec Section 7: Track tempo drift relative to grid.
-   *
-   * Method: for each accepted hit compute its absolute quantized step index
-   *   absStep = round((timestamp - startTime) / stepDurMs)
-   * then use the step delta between consecutive accepted hits to estimate BPM:
-   *   bpmSample = (stepDelta * 60) / ((division/4) * timeDeltaSecs)
-   * This is correct even when the drummer plays quarters in a 16ths groove (#122)
-   * because stepDelta reflects the actual steps skipped, not a raw hit count.
-   *
-   * Flam/simultaneous hits (stepDelta=0): skip EWMA update entirely,
-   * keeping last* unchanged so the next genuine onset measures from the real previous hit.
-   *
-   * Deviation check: getPerformedBpm() returns null when |estimate - tempo|/tempo > 0.2,
-   * but the internal estimate is NOT zeroed — preventing oscillation between null and a value.
-   * @private
-   */
-  private updatePerformedBpmEstimate(timestamp: number): void {
-    if (this.startTime == null) return;
-
-    // Beat = quarter note (engine source of truth) — consistent with buildOffsetGrid (#123)
-    const stepsPerBeat = this.division / 4;
-    const beatDurMs = (60 / this.tempo) * 1000;
-    const stepDurMs = beatDurMs / stepsPerBeat;
-
-    // Absolute quantized step index for this hit
-    const absStep = Math.round((timestamp - this.startTime) / stepDurMs);
-
-    if (this.lastAbsStep === null || this.lastTimestamp === null) {
-      // Seed: record position but no BPM sample yet
-      this.lastAbsStep = absStep;
-      this.lastTimestamp = timestamp;
-      return;
-    }
-
-    const stepDelta = absStep - this.lastAbsStep;
-
-    if (stepDelta < 1) {
-      // Simultaneous / flam hit: ignore this onset for BPM estimation.
-      // Keep last* unchanged so the next genuine onset measures from the real previous hit.
-      return;
-    }
-
-    if (stepDelta < stepsPerBeat) {
-      // Sub-beat interval: too short to measure BPM accurately.
-      // A 15ms timing error on a 125ms window (16th at 120 BPM) inflates the sample by ~13%.
-      // The same error on a 500ms beat window is only ~3%. Advance the pointer and wait.
-      this.lastAbsStep = absStep;
-      this.lastTimestamp = timestamp;
-      return;
-    }
-
-    const timeDeltaSecs = (timestamp - this.lastTimestamp) / 1000;
-    if (timeDeltaSecs <= 0) {
-      // Guard against zero/negative time delta
-      this.lastAbsStep = absStep;
-      this.lastTimestamp = timestamp;
-      return;
-    }
-
-    // bpmSample = (stepDelta / stepsPerBeat) beats / timeDeltaSecs seconds * 60
-    const bpmSample = (stepDelta * 60) / (stepsPerBeat * timeDeltaSecs);
-
-    if (this.bpmEstimate === null) {
-      this.bpmEstimate = bpmSample;
-    } else {
-      // EWMA smoothing: newEst = oldEst + alpha * (sample - oldEst)
-      this.bpmEstimate += this.EWMA_ALPHA * (bpmSample - this.bpmEstimate);
-    }
-
-    // Advance last hit pointers
-    this.lastAbsStep = absStep;
-    this.lastTimestamp = timestamp;
-  }
-
-  /**
    * Get EWMA-smoothed performed BPM (actual tempo from drummer's hits).
    * Returns null if deviation from set tempo exceeds 20% or insufficient data.
-   * The internal estimate is NOT nulled on deviation — only the return value is null.
-   * This prevents oscillation between valid and null readings (#122).
    */
   getPerformedBpm(): number | null {
-    if (this.bpmEstimate === null) return null;
-    const deviation = Math.abs(this.bpmEstimate - this.tempo) / this.tempo;
-    if (deviation > 0.2) return null;
-    return Math.round(this.bpmEstimate * 10) / 10;
+    return this.bpmEstimator.getPerformedBpm(this.tempo);
   }
 
   /**
    * Get current performance statistics
    */
   getStats(): PerformanceStats {
-    // Return deep copy to prevent external mutation of internal state (Issue #95)
     return { ...this.stats, timingScores: [...this.stats.timingScores] };
   }
 

--- a/src/midi/performanceGrader.ts
+++ b/src/midi/performanceGrader.ts
@@ -1,0 +1,90 @@
+/**
+ * Pure performance grading functions — extracted from PerformanceTracker.
+ * All functions are stateless and accept required values as parameters.
+ */
+
+import { DrumVoice } from '../types';
+import { GroovePattern } from './PerformanceTracker';
+
+/**
+ * Calculate signed timing error and absolute error.
+ * Spec Section 5: Quantize to nearest offset in beat grid.
+ *
+ * @param posInBeat - ms elapsed within the current beat (elapsedMs % beatDurMs)
+ * @param beatDurMs - duration of one beat in ms
+ * @param beatOffsets - swing-aware grid offsets within one beat
+ */
+export function calculateTimingError(
+  posInBeat: number,
+  beatDurMs: number,
+  beatOffsets: number[]
+): { errorMs: number; absError: number } {
+  let minDist = Infinity;
+  let nearestOffset = 0;
+  for (const offset of beatOffsets) {
+    const dist = Math.abs(posInBeat - offset);
+    if (dist < minDist) {
+      minDist = dist;
+      nearestOffset = offset;
+    }
+  }
+  // Also consider next-beat downbeat: a hit just before the downbeat reports a small
+  // negative error instead of a large late error (e.g. posInBeat=490, beatDurMs=500 → -10ms)
+  const nextDownbeatDist = Math.abs(posInBeat - beatDurMs);
+  if (nextDownbeatDist < minDist) {
+    nearestOffset = beatDurMs;
+  }
+
+  const errorMs = posInBeat - nearestOffset; // signed: negative=slow, positive=fast
+  return { errorMs, absError: Math.abs(errorMs) };
+}
+
+/**
+ * Calculate timing accuracy with tempo-aware thresholds.
+ * Spec Section 6: Use tempo-aware grading bands.
+ *
+ * @param absError - absolute timing error in ms
+ * @param beatDurMs - duration of one beat in ms (for tempo-aware scaling)
+ */
+export function calculateTimingAccuracy(absError: number, beatDurMs: number): number {
+  const acceptWindow = Math.min(90, beatDurMs * 0.18);
+  const onTimeMs = Math.min(25, beatDurMs * 0.05);
+
+  if (absError > acceptWindow) return 0;       // Miss
+  if (absError <= onTimeMs) return 100;         // Perfect
+  if (absError <= onTimeMs * 2) return 75;      // Good
+  if (absError <= acceptWindow * 0.55) return 50; // Fair
+  return 25;                                    // Poor
+}
+
+/**
+ * Check if the hit note matches the loaded pattern at the current step.
+ *
+ * @param grooveVoice - Voice that was hit
+ * @param currentStep - Current step index (wraps across all measures)
+ * @param loadedPattern - Flattened groove pattern
+ */
+export function checkNoteAccuracy(
+  grooveVoice: DrumVoice,
+  currentStep: number,
+  loadedPattern: GroovePattern | null
+): number {
+  if (!loadedPattern?.voices) return 50; // No pattern, can't verify
+
+  const voicePattern = loadedPattern.voices[grooveVoice];
+  if (!voicePattern || voicePattern.length === 0) return 30; // Voice not in pattern
+
+  const stepInMeasure = currentStep % voicePattern.length;
+  return voicePattern[stepInMeasure] ? 80 : 30; // On-step vs wrong position
+}
+
+/**
+ * Get performance feedback message for an overall accuracy score.
+ */
+export function getFeedback(accuracy: number): string {
+  if (accuracy >= 90) return 'Perfect!';
+  if (accuracy >= 75) return 'Great!';
+  if (accuracy >= 60) return 'Good';
+  if (accuracy >= 40) return 'Keep trying';
+  return 'Miss';
+}

--- a/src/pages/ProductionPage.tsx
+++ b/src/pages/ProductionPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { GrooveData, DEFAULT_GROOVE, DrumVoice, Division, ALL_DRUM_VOICES, TimeSignature, StickingValue, createEmptySticking, MeasureConfig, MAX_MEASURES } from '../types';
+import { GrooveData, DEFAULT_GROOVE, DrumVoice, Division, ALL_DRUM_VOICES, TimeSignature } from '../types';
 import { GrooveUtils, decodeGroove, SavedGroove } from '../core';
 import { useGrooveEngine } from '../hooks/useGrooveEngine';
 import { useHistory } from '../hooks/useHistory';
@@ -13,6 +13,10 @@ import { useMIDIInput } from '../hooks/useMIDIInput';
 import { useMIDIFeedback } from '../hooks/useMIDIFeedback';
 import { useMIDITracking } from '../hooks/useMIDITracking';
 import { useMIDITrackingFeedback } from '../hooks/useMIDITrackingFeedback';
+import { useModalState } from '../hooks/useModalState';
+import { useStickingState } from '../hooks/useStickingState';
+import { useMeasureCopyPaste } from '../hooks/useMeasureCopyPaste';
+import { usePlaybackState } from '../hooks/usePlaybackState';
 import * as analytics from '../utils/analytics';
 import { frequencyToMetronomeOption, metronomeOptionToFrequency } from '../utils/metronomeConstants';
 import '../styles/midi.css';
@@ -39,92 +43,12 @@ import { ShareModal } from '../components/production/ShareModal';
 import { TimeSignatureSelectorModal } from '../components/production/TimeSignatureSelectorModal';
 import './ProductionPage.css';
 
+// Re-exported for backward compatibility (tests import from this path)
+export { findSimilarMeasures, applyStickingToSimilar } from '../core/stickingUtils';
+
 const TITLE_MAX_LENGTH = 50;
 const AUTHOR_MAX_LENGTH = 50;
 const COMMENT_MAX_LENGTH = 300;
-
-/**
- * Compare two notes records for exact equality across all drum voices.
- * Two measures are considered identical if every voice has matching boolean arrays.
- * Articulation differences (hihat-open vs hihat-closed) count as different because
- * they are separate DrumVoice values (D-05).
- */
-function areNotesIdentical(
-  notes1: Record<DrumVoice, boolean[]>,
-  notes2: Record<DrumVoice, boolean[]>
-): boolean {
-  return ALL_DRUM_VOICES.every(voice => {
-    const arr1 = notes1[voice];
-    const arr2 = notes2[voice];
-    if (!arr1 || !arr2) return arr1 === arr2;
-    if (arr1.length !== arr2.length) return false;
-    return arr1.every((v, i) => v === arr2[i]);
-  });
-}
-
-/**
- * Find measures with the same note pattern as the target measure.
- * Similarity criteria (per D-05):
- * - Same time signature (beats x noteValue)
- * - Same subdivision count (notesPerMeasure)
- * - Identical note patterns across all voices (including articulation)
- *
- * Returns indices of similar measures, excluding the target measure itself.
- */
-export function findSimilarMeasures(groove: GrooveData, targetMeasureIndex: number): number[] {
-  const target = groove.measures[targetMeasureIndex];
-  if (!target) return [];
-
-  const targetTs = target.timeSignature || groove.timeSignature;
-  const targetNotesPerMeasure = GrooveUtils.calcNotesPerMeasure(
-    groove.division,
-    targetTs.beats,
-    targetTs.noteValue
-  );
-
-  const similar: number[] = [];
-  for (let i = 0; i < groove.measures.length; i++) {
-    if (i === targetMeasureIndex) continue;
-    const candidate = groove.measures[i];
-    const candidateTs = candidate.timeSignature || groove.timeSignature;
-
-    // Check time signature match (beats and noteValue must both match)
-    if (
-      candidateTs.beats !== targetTs.beats ||
-      candidateTs.noteValue !== targetTs.noteValue
-    ) {
-      continue;
-    }
-
-    // Check subdivision count match
-    const candidateNotesPerMeasure = GrooveUtils.calcNotesPerMeasure(
-      groove.division,
-      candidateTs.beats,
-      candidateTs.noteValue
-    );
-    if (candidateNotesPerMeasure !== targetNotesPerMeasure) continue;
-
-    // Check note pattern identity across all voices
-    if (areNotesIdentical(target.notes, candidate.notes)) {
-      similar.push(i);
-    }
-  }
-
-  return similar;
-}
-
-/**
- * Apply the sticking from a source measure to all similar measures.
- * Returns the set of measure indices that were updated (for feedback messages).
- * Returns empty array if source has no sticking or no similar measures found.
- * The sticking array is deep-copied to each target measure (T-02-09).
- */
-export function applyStickingToSimilar(groove: GrooveData, sourceMeasureIndex: number): number[] {
-  const sourceSticking = groove.measures[sourceMeasureIndex]?.sticking;
-  if (!sourceSticking || !sourceSticking.some(v => v !== null)) return [];
-
-  return findSimilarMeasures(groove, sourceMeasureIndex);
-}
 
 function sanitizeMetadataValue(value: string, maxLength: number): string {
   return value
@@ -138,26 +62,22 @@ function sanitizeMetadataValue(value: string, maxLength: number): string {
 export default function ProductionPage() {
   const [advancedEditMode] = useState(false);
   const [isNotesOnly, setIsNotesOnly] = useState(false);
-  const [isStickingSetupActive, setIsStickingSetupActive] = useState(false);
-  const [isDownloadModalOpen, setIsDownloadModalOpen] = useState(false);
-  const [isPrintModalOpen, setIsPrintModalOpen] = useState(false);
-  const [isMyGroovesModalOpen, setIsMyGroovesModalOpen] = useState(false);
-  const [isSaveGrooveModalOpen, setIsSaveGrooveModalOpen] = useState(false);
-  const [isGrooveLibraryModalOpen, setIsGrooveLibraryModalOpen] = useState(false);
-  const [isShareModalOpen, setIsShareModalOpen] = useState(false);
-  const [isTimeSignatureModalOpen, setIsTimeSignatureModalOpen] = useState(false);
-  const [elapsedTime, setElapsedTime] = useState('0:00');
-  const [isCountingIn, setIsCountingIn] = useState(false);
-  const [countdownNumber, setCountdownNumber] = useState<number | null>(null);
-  const [countingInButton, setCountingInButton] = useState<'play' | 'playPlus' | null>(null);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [midiTrackingEnabled, setMidiTrackingEnabled] = useState(false);
   const [isMetadataEditing, setIsMetadataEditing] = useState(false);
   const [syncOffset] = useState<number>(loadSyncOffset);
-  const playStartTimeRef = useRef<number | null>(null);
-  const countInTimeoutRef = useRef<number | null>(null);
   const metadataFieldsRef = useRef<MetadataFieldsRef>(null);
-  const copiedMeasureRef = useRef<MeasureConfig | null>(null);
+
+  // Modal open/close state
+  const {
+    isDownloadModalOpen, setIsDownloadModalOpen,
+    isPrintModalOpen, setIsPrintModalOpen,
+    isMyGroovesModalOpen, setIsMyGroovesModalOpen,
+    isSaveGrooveModalOpen, setIsSaveGrooveModalOpen,
+    isGrooveLibraryModalOpen, setIsGrooveLibraryModalOpen,
+    isShareModalOpen, setIsShareModalOpen,
+    isTimeSignatureModalOpen, setIsTimeSignatureModalOpen,
+  } = useModalState();
 
   // Responsive detection
   const { isMobile } = useResponsive();
@@ -306,125 +226,16 @@ export default function ProductionPage() {
     setEngineSyncMode('start');
   }, [setEngineSyncMode]);
 
-  // Track elapsed time during playback
-  useEffect(() => {
-    if (isPlaying) {
-      // Start tracking time
-      playStartTimeRef.current = Date.now();
-
-      const updateElapsedTime = () => {
-        if (playStartTimeRef.current) {
-          const elapsed = Date.now() - playStartTimeRef.current;
-          const seconds = Math.floor(elapsed / 1000);
-          const minutes = Math.floor(seconds / 60);
-          const remainingSeconds = seconds % 60;
-          setElapsedTime(`${minutes}:${remainingSeconds.toString().padStart(2, '0')}`);
-        }
-      };
-
-      // Update every 100ms for smooth display
-      const intervalId = setInterval(updateElapsedTime, 100);
-      updateElapsedTime(); // Initial update
-
-      return () => {
-        clearInterval(intervalId);
-      };
-    } else {
-      // Reset when stopped
-      playStartTimeRef.current = null;
-      setElapsedTime('0:00');
-    }
-  }, [isPlaying]);
-
-  // Keyboard shortcuts
-
-  // Cancel count-in helper
-  const cancelCountIn = useCallback(() => {
-    if (countInTimeoutRef.current) {
-      clearTimeout(countInTimeoutRef.current);
-      countInTimeoutRef.current = null;
-    }
-    setIsCountingIn(false);
-    setCountdownNumber(null);
-    setCountingInButton(null);
-  }, []);
-
-  // Play count-in clicks (4 beats with metronome sounds)
-  const playCountIn = useCallback(async (button: 'play' | 'playPlus'): Promise<boolean> => {
-    return new Promise((resolve) => {
-      const beatDuration = 60000 / groove.tempo; // ms per beat
-      let currentBeat = 4; // Start at 4, count down to 1
-
-      setIsCountingIn(true);
-      setCountingInButton(button);
-      setCountdownNumber(currentBeat);
-
-      const playBeat = () => {
-        if (currentBeat > 0) {
-          // Play metronome click - same sound for all 4 beats
-          playPreview('hihat-metronome-normal');
-          setCountdownNumber(currentBeat);
-          currentBeat--;
-          countInTimeoutRef.current = window.setTimeout(playBeat, beatDuration);
-        } else {
-          setIsCountingIn(false);
-          setCountdownNumber(null);
-          setCountingInButton(null);
-          resolve(true); // Count-in completed successfully
-        }
-      };
-
-      playBeat();
-    });
-  }, [groove.tempo, playPreview]);
-
-  const handlePlay = useCallback(async () => {
-    if (autoSpeedUp.isActive) autoSpeedUp.stop();
-
-    // If counting in, cancel it
-    if (isCountingIn) {
-      cancelCountIn();
-      return;
-    }
-
-    if (isPlaying) {
-      // Stop playback
-      const duration = playStartTimeRef.current ? (Date.now() - playStartTimeRef.current) / 1000 : 0;
-      analytics.trackStop('normal', duration);
-      stop();
-    } else {
-      // Start playback (with count-in if enabled in metronome options)
-      if (metronomeConfig.countIn) {
-        const completed = await playCountIn('play');
-        if (!completed) return; // Count-in was cancelled
-      }
-      analytics.trackPlay('normal', groove.tempo, `${groove.timeSignature.beats}/${groove.timeSignature.noteValue}`);
-      await play(groove);
-    }
-  }, [autoSpeedUp, isCountingIn, cancelCountIn, isPlaying, playStartTimeRef, stop, metronomeConfig.countIn, playCountIn, analytics, groove, play]);
-
-  const handlePlayWithSpeedUp = async () => {
-    // If counting in, cancel it
-    if (isCountingIn) {
-      cancelCountIn();
-      return;
-    }
-
-    if (isPlaying) {
-      const duration = playStartTimeRef.current ? (Date.now() - playStartTimeRef.current) / 1000 : 0;
-      analytics.trackStop('speed-up', duration);
-      autoSpeedUp.stop();
-      stop();
-    } else {
-      if (metronomeConfig.countIn) {
-        const completed = await playCountIn('playPlus');
-        if (!completed) return; // Count-in was cancelled
-      }
-      analytics.trackPlay('speed-up', groove.tempo, `${groove.timeSignature.beats}/${groove.timeSignature.noteValue}`);
-      await play(groove);
-      autoSpeedUp.start();
-    }
-  };
+  // Playback state: elapsed time, count-in, play/stop handlers
+  const { elapsedTime, countdownNumber, countingInButton, handlePlay, handlePlayWithSpeedUp } = usePlaybackState({
+    groove,
+    play,
+    stop,
+    isPlaying,
+    metronomeConfig,
+    autoSpeedUp,
+    playPreview,
+  });
 
   // Keyboard shortcuts
   useEffect(() => {
@@ -580,94 +391,11 @@ export default function ProductionPage() {
     analytics.trackMetronomeChange(option);
   };
 
-  const handleStickingSetupToggle = useCallback(() => {
-    setIsStickingSetupActive(prev => !prev);
-  }, []);
+  // Sticking setup state and handlers
+  const { isStickingSetupActive, handleStickingSetupToggle, handleStickingChange, handleApplyToSimilar } = useStickingState(groove, setGroove);
 
-  const handleStickingChange = useCallback((measureIndex: number, subdivIndex: number, value: StickingValue) => {
-    const measure = groove.measures[measureIndex];
-    if (!measure) return;
-
-    // Determine subdivision count for this measure
-    const ts = measure.timeSignature || groove.timeSignature;
-    const subdivCount = GrooveUtils.calcNotesPerMeasure(groove.division, ts.beats, ts.noteValue);
-
-    // Validate bounds (T-02-03)
-    if (subdivIndex < 0 || subdivIndex >= subdivCount) return;
-
-    // Build the updated sticking array, validating length invariant (T-02-03)
-    const existingSticking: StickingValue[] = (measure.sticking && measure.sticking.length === subdivCount)
-      ? [...measure.sticking]
-      : createEmptySticking(subdivCount);
-
-    existingSticking[subdivIndex] = value;
-
-    const updatedGroove: GrooveData = {
-      ...groove,
-      measures: groove.measures.map((m, i) =>
-        i === measureIndex ? { ...m, sticking: existingSticking } : m
-      ),
-    };
-    setGroove(updatedGroove);
-  }, [groove, setGroove]);
-
-  const cloneMeasure = useCallback((measure: MeasureConfig): MeasureConfig => ({
-    ...measure,
-    notes: Object.fromEntries(
-      Object.entries(measure.notes).map(([voice, notes]) => [voice, [...notes]])
-    ) as MeasureConfig['notes'],
-    sticking: measure.sticking ? [...measure.sticking] : undefined,
-  }), []);
-
-  const handleMeasureCopy = useCallback((measureIndex: number) => {
-    const measure = groove.measures[measureIndex];
-    if (!measure) return;
-    copiedMeasureRef.current = cloneMeasure(measure);
-  }, [cloneMeasure, groove.measures]);
-
-  const handleMeasurePaste = useCallback((afterIndex: number): boolean => {
-    if (!copiedMeasureRef.current || groove.measures.length >= MAX_MEASURES) {
-      return false;
-    }
-
-    const measureToPaste = cloneMeasure(copiedMeasureRef.current);
-    const insertIndex = Math.min(afterIndex + 1, groove.measures.length);
-    setGroove({
-      ...groove,
-      measures: [
-        ...groove.measures.slice(0, insertIndex),
-        measureToPaste,
-        ...groove.measures.slice(insertIndex),
-      ],
-    });
-    return true;
-  }, [cloneMeasure, groove, setGroove]);
-
-  /**
-   * Apply sticking from the given measure to all measures with identical note patterns.
-   * Returns a message describing the result (for display in the measure header feedback).
-   * Uses deep copy for each target to prevent shared references (T-02-09).
-   */
-  const handleApplyToSimilar = useCallback((measureIndex: number): string => {
-    const similarIndices = applyStickingToSimilar(groove, measureIndex);
-    if (similarIndices.length === 0) {
-      return 'No similar measures found.';
-    }
-
-    const sourceSticking = groove.measures[measureIndex].sticking!;
-    const updatedGroove: GrooveData = {
-      ...groove,
-      measures: groove.measures.map((m, i) =>
-        similarIndices.includes(i)
-          ? { ...m, sticking: [...sourceSticking] } // T-02-09: deep copy
-          : m
-      ),
-    };
-    setGroove(updatedGroove);
-
-    const count = similarIndices.length;
-    return `Applied to ${count} similar ${count === 1 ? 'measure' : 'measures'}.`;
-  }, [groove, setGroove]);
+  // Measure copy/paste clipboard
+  const { handleMeasureCopy, handleMeasurePaste } = useMeasureCopyPaste(groove, setGroove);
 
   return (
     <div className="min-h-dvh flex flex-col bg-slate-100 dark:bg-slate-900 text-slate-900 dark:text-white">


### PR DESCRIPTION
## Summary

Splits 7 large source files (489–885 lines each) into focused, single-responsibility modules. **No behavior changes** — all public APIs, import paths, and test suites are preserved unchanged. Every commit is atomic and independently reviewable.

## Linked issues

Closes #126
Closes #127
Closes #128
Closes #129
Closes #130
Closes #131
Closes #132

## What changed

### #126 — ProductionPage.tsx (865 → 593 lines, -31%)
Four hooks extracted to reduce the megacomponent to rendering + composition only:
- `src/hooks/useModalState.ts` — 7 modal booleans consolidated
- `src/hooks/usePlaybackState.ts` — count-in, elapsed time, speed-up handlers
- `src/hooks/useStickingState.ts` — sticking setup mode + apply-to-similar
- `src/hooks/useMeasureCopyPaste.ts` — copy/paste measure state + handlers
- `src/core/stickingUtils.ts` — pure functions moved from component to framework-agnostic layer (re-exported via ProductionPage for backward compat with existing tests)

### #127 — ExportUtils.ts (885 → 38-line shim)
Split into format-specific modules under `src/core/exporters/`:
- `helpers.ts` — shared types, lazy-load caches (jsPDF, qrcode, midi-writer, lamejs), utilities
- `exportJSON.ts` — JSON export
- `exportImage.ts` — SVG / PNG / PDF export
- `exportAudio.ts` — MIDI / MP3 export
- `index.ts` — barrel re-export
- `ExportUtils.ts` now re-exports everything; all callers unaffected

### #128 — DrumGridDark.tsx (789 → 448 lines, -43%)
- `src/hooks/useKeyboardEditor.ts` (423 lines) — all keyboard navigation state, cursor movement, variation menu, 11-variant `handleKeyboardEditKeyDown`

### #129 — GrooveEngine.ts (742 → 460 lines, -38%)
- `src/core/MetronomeManager.ts` (153 lines) — config state, rotation offset, `shouldPlayClick`, `onLoopComplete`, `resetRotation`
- GrooveEngine holds `private readonly metronome = new MetronomeManager()` and delegates all metronome methods

### #130 — useDrumGrid.ts (613 → 238 lines, -61%)
- `src/hooks/useGridDragPaint.ts` (211 lines) — drag/paint state, touch, global mouseup effect
- `src/hooks/useGridContextMenu.ts` (274 lines) — context menu + bulk dialog, click handlers, keyboard shortcut effect
- `isDragging` guard on `handleLeftClick` lives in `useDrumGrid` wrapper (not `useGridContextMenu`) — keeps React Rules of Hooks intact

### #131 — GrooveURLCodec.ts (599 → 388 lines, -35%)
- `src/core/urlCodecSchemas.ts` (103 lines) — VALIDATION, all Zod schemas, `safeParse`, shared constants
- `src/core/stickingCodec.ts` (91 lines) — sticking encode/decode functions

### #132 — PerformanceTracker.ts (559 → 334 lines, -40%)
- `src/midi/BPMEstimator.ts` (94 lines) — EWMA BPM estimation class (Spec §7)
- `src/midi/performanceGrader.ts` (90 lines) — pure timing accuracy functions

## Test plan

- [x] All 239 tests pass before and after each commit
- [x] `npx tsc --noEmit` clean at every step
- [x] No import paths changed for existing consumers
- [x] No behavior changes — purely structural refactoring

## Reviewer notes

- Each commit maps 1:1 to a GitHub issue and is independently reviewable
- The `refactor(131+132)` commit covers two issues in one atomic commit because they targeted the same related area
- `DrumGridDark` was done by a worktree agent (commit `ec44e4f`) and merged via `6da5726`