### PR TITLE
fix: snap performed BPM display to set tempo within ±1 and round to integer

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -86,6 +86,7 @@ None currently. Ready to begin Phase 1 planning.
 | 260614-h0t | Per-tab default for the "Share as:" urlMode toggle in ShareModal | 2026-06-14 | acd89e5 | [260614-h0t-in-sharemodal-tsx-make-the-share-as-urlm](./quick/260614-h0t-in-sharemodal-tsx-make-the-share-as-urlm/) |
 | 260624-dy6 | Refactor ProductionPage.tsx: extract useModalState, useMeasureOperations, usePlaybackState, useStickingState hooks | 2026-06-24 | a3e5c85 | [260624-dy6-refactor-productionpage-tsx-extract-usem](./quick/260624-dy6-refactor-productionpage-tsx-extract-usem/) |
 | 260703-m1a | Fix upward bias in BPMEstimator (interval rounding + sub-beat samples) | 2026-07-03 | 52e75c9 | [260703-m1a-fix-upward-bias-in-bpmestimator-interval](./quick/260703-m1a-fix-upward-bias-in-bpmestimator-interval/) |
+| 260704-t3f | Round performed BPM display to integer and snap to set tempo within ±1 BPM | 2026-07-04 | d75104f | [260704-t3f-round-performed-bpm-display-to-integer-a](./quick/260704-t3f-round-performed-bpm-display-to-integer-a/) |
 
 ## Next Steps
 
@@ -107,4 +108,4 @@ None currently. Ready to begin Phase 1 planning.
 - Decisions captured: 4 (Handler Lifecycle, Listener Dependencies, Cleanup Strategy, Memory Verification)
 - Next: Plan Phase 1
 
-Last activity: 2026-07-03 - Completed quick task 260703-m1a: Fix upward bias in BPMEstimator (interval rounding + sub-beat samples)
+Last activity: 2026-07-04 - Completed quick task 260704-t3f: Round performed BPM display to integer and snap to set tempo within ±1 BPM

--- a/src/midi/BPMEstimator.ts
+++ b/src/midi/BPMEstimator.ts
@@ -95,11 +95,21 @@ export class BPMEstimator {
    * Get smoothed BPM estimate. Returns null if deviation from set tempo
    * exceeds 20% or insufficient data collected yet.
    * The internal estimate is NOT nulled on deviation — prevents oscillation (#122).
+   *
+   * Display-level snap + integer rounding: the EWMA rate-average is upward-biased
+   * under human timing jitter (Jensen's inequality — worse for dense 8th/16th
+   * playing), leaving a sub-±1 BPM residual even when a drummer is exactly on
+   * tempo. That residual is noise, not signal, so estimates within ±1 BPM of the
+   * set tempo snap to the set tempo exactly, and everything else is rounded to
+   * the nearest integer. The estimation math above is intentionally unchanged —
+   * a period-averaging alternative was tested and rejected for over-correcting
+   * dense playing.
    */
   getPerformedBpm(tempo: number): number | null {
     if (this.bpmEstimate === null) return null;
     const deviation = Math.abs(this.bpmEstimate - tempo) / tempo;
     if (deviation > 0.2) return null;
-    return Math.round(this.bpmEstimate * 10) / 10;
+    if (Math.abs(this.bpmEstimate - tempo) <= 1) return tempo;
+    return Math.round(this.bpmEstimate);
   }
 }

--- a/src/midi/PerformanceTracker.test.ts
+++ b/src/midi/PerformanceTracker.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { performanceTracker } from './PerformanceTracker';
+import { BPMEstimator } from './BPMEstimator';
 import type { GrooveData } from '../types';
 
 describe('PerformanceTracker', () => {
@@ -774,5 +775,38 @@ describe('PerformanceTracker', () => {
       expect(result!.timingAccuracy).toBeGreaterThanOrEqual(0);
       expect(result!.timingAccuracy).toBeLessThanOrEqual(100);
     });
+  });
+});
+
+describe('getPerformedBpm display snap + integer rounding', () => {
+  it('snaps estimates within ±1 BPM of set tempo to the set tempo exactly', () => {
+    const estimator = new BPMEstimator();
+    // division=4 -> stepsPerBeat=1, stepDurMs=500 at tempo 120.
+    estimator.update(0, 120, 4); // seeds lastTimestamp
+    estimator.update(496.688, 120, 4); // bpmSample ≈ 120.8, stepDelta = 1
+
+    expect(estimator.getPerformedBpm(120)).toBe(120);
+  });
+
+  it('rounds estimates outside ±1 BPM to the nearest integer (no decimal)', () => {
+    const estimator = new BPMEstimator();
+    estimator.update(0, 120, 4);
+    estimator.update(486.224, 120, 4); // bpmSample ≈ 123.4
+
+    expect(estimator.getPerformedBpm(120)).toBe(123);
+  });
+
+  it('returns null when no estimate has been seeded', () => {
+    const estimator = new BPMEstimator();
+
+    expect(estimator.getPerformedBpm(120)).toBeNull();
+  });
+
+  it('returns null when estimate deviates more than 20% from set tempo (unchanged gate)', () => {
+    const estimator = new BPMEstimator();
+    estimator.update(0, 120, 4);
+    estimator.update(300, 120, 4); // bpmSample ≈ 200, deviation > 20%
+
+    expect(estimator.getPerformedBpm(120)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- `BPMEstimator.getPerformedBpm()` now returns the set tempo exactly when the EWMA estimate is within ±1 BPM of it, and a whole number (no decimals) otherwise.
- Fixes the readout showing 120.5–121.5 while playing on time at 120 BPM.

## Why display-level
The estimator averages per-interval BPM rates; under human timing jitter this is inherently biased ~+0.5–1.9 BPM high (Jensen's inequality), worse at 8th/16th-note density. Averaging periods instead was simulated and rejected — it over-corrects downward for dense playing. Sub-BPM precision is noise, not signal, so the snap/round happens at read time; the internal estimate and the >20%-deviation null gate are unchanged (preserves the #122 anti-oscillation invariant).

## Testing
- 4 new unit tests: snap (120.8→120), round (123.4→123), null seed, >20% deviation gate
- Full suite: 245/245 pass, `tsc -b` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)